### PR TITLE
Fix config typo

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -29,7 +29,7 @@ public class SingerConfigDef {
   public static final String DAILY_RESTART_FLAG = "daily";
   public static final String NUMBER_OF_FAILURES_ALLOWED = "numberOfFailuresAllowed";
   public static final String DAILY_RESTART_TIME_BEGIN = "dailyRestartUtcTimeRangeBegin";
-  public static final String DAILY_RESTART_TIME_END = "dailyRestartUtcTimeRangeBegin";
+  public static final String DAILY_RESTART_TIME_END = "dailyRestartUtcTimeRangeEnd";
 
   public static final String MONITOR_INTERVAL_IN_SECS = "monitorIntervalInSecs";
 

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -268,8 +268,8 @@ public class LogConfigUtils {
           .getString(SingerConfigDef.DAILY_RESTART_TIME_END);
       Date startTime = SingerUtils.convertToDate(restartConfig.dailyRestartUtcTimeRangeBegin);
       Date endTime = SingerUtils.convertToDate(restartConfig.dailyRestartUtcTimeRangeEnd);
-      if (endTime.compareTo(startTime) < 0) {
-        throw new ConfigurationException("Daily restart end time is earlier than start time");
+      if (endTime.compareTo(startTime) <= 0) {
+        throw new ConfigurationException("Daily restart end time is not later than start time");
       }
     }
     return restartConfig;


### PR DESCRIPTION
`DAILY_RESTART_TIME_END` used to be same as `DAILY_RESTART_TIME_BEGIN`, which will cause the restart time randomization fail to work.
Also changed the config check to verify if endTime is strictly larger than startTime.