### PR TITLE
Fixing the unit tests errors in singer

### DIFF
--- a/singer/src/test/java/com/pinterest/singer/SingerTestBase.java
+++ b/singer/src/test/java/com/pinterest/singer/SingerTestBase.java
@@ -241,7 +241,7 @@ public class SingerTestBase extends TestCase {
         put("topic_names", "topic1, topic2");
 
         put("topic1.name", "topic1");
-        put("topic1.owner", "team1");
+        put("topic1.owner", "owner1");
         put("topic1.type", "JSON");
         put("topic1.daily_datavolume", "1024");
         // we need this line to cheat the producer parser, otherwise it tries to resolve server set.
@@ -249,12 +249,12 @@ public class SingerTestBase extends TestCase {
         put("topic1.processor.batchSize", "200");
 
         put("topic2.name", "topic2");
-        put("topic2.owner", "team2");
+        put("topic2.owner", "owner2");
         put("topic2.type", "JSON");
         put("topic2.daily_datavolume", "2048");
         // we need this line to cheat the producer parser, otherwise it tries to resolve server set.
-        put("discovery.writer.kafka.producerConfig.bootstrap.servers", "broken_list_for_testing");
-        put("discovery.processor.batchSize", "200");
+        put("topic2.writer.kafka.producerConfig.bootstrap.servers", "broken_list_for_testing");
+        put("topic2.processor.batchSize", "200");
 
         put("singer.default.processor.processingIntervalInSeconds", "1");
         put("singer.default.reader.type", "thrift");
@@ -275,6 +275,7 @@ public class SingerTestBase extends TestCase {
         put("singer.default.writer.kafka.producerConfig.ssl.truststore.password", "truststore_password");
         put("singer.default.writer.kafka.producerConfig.ssl.truststore.type", "JKS");
         put("singer.default.logDir", "/mnt/thrift_logger/");
+
       }
     };
   }

--- a/singer/src/test/java/com/pinterest/singer/config/DirectorySingerConfiguratorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/config/DirectorySingerConfiguratorTest.java
@@ -47,8 +47,10 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
     // Make the singer config property file
     File singerConfigFile = createSingerConfigFile(makeDirectorySingerConfigProperties());
     // Make two log config properties files in the logConfigDir.
-    createLogConfigPropertiesFile("ads.mohawk.properties");
-    File searchLogConfig = createLogConfigPropertiesFile("search.discovery.properties");
+    createLogConfigPropertiesFile("ads.mohawk.properties", ImmutableMap.of(
+        "writer.kafka.producerConfig.bootstrap.servers", "127.0.0.1:9092"));
+    File searchLogConfig = createLogConfigPropertiesFile("search.discovery.properties",
+        ImmutableMap.of("writer.kafka.producerConfig.bootstrap.servers", "127.0.0.1:9092"));
 
     // Check the configurator can load two log configs.
     DirectorySingerConfigurator configurator = new DirectorySingerConfigurator(singerConfigFile
@@ -72,7 +74,8 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
 
     {
       // Test live changes : adding a new file.
-      createLogConfigPropertiesFile("ads.ads.properties");
+      createLogConfigPropertiesFile("ads.ads.properties", ImmutableMap.of(
+          "writer.kafka.producerConfig.bootstrap.servers", "127.0.0.1:9092"));
       Thread.sleep(2000);
       // check exit() called with code 0.
       assertEquals(0, exitCode.get());
@@ -85,7 +88,7 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
     {
       // Test live changes : modifying a config to increase batch size from 200 to 300.
       createLogConfigPropertiesFile("ads.mohawk.properties", ImmutableMap.of("processor.batchSize",
-          "300"));
+          "300", "writer.kafka.producerConfig.bootstrap.servers", "127.0.0.1:9092"));
       Thread.sleep(2000);
       assertEquals(0, exitCode.get());
     }
@@ -133,12 +136,12 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
     SingerLogConfig[] logConfigs = LogConfigUtils.parseLogStreamConfigFromFile(newConfig);
 
     assertEquals(2, logConfigs.length);
-    SingerLogConfig adsMohawk = logConfigs[0];
-    assertEquals("mohawk", adsMohawk.getName());
-    assertEquals("/mnt/thrift_logger", adsMohawk.getLogDir());
-    SingerLogConfig search = logConfigs[1];
-    assertEquals("discovery", search.getName());
-    assertEquals("/mnt/thrift_logger", search.getLogDir());
+    SingerLogConfig topic1 = logConfigs[0];
+    assertEquals("topic1", topic1.getName());
+    assertEquals("/mnt/thrift_logger", topic1.getLogDir());
+    SingerLogConfig topic2 = logConfigs[1];
+    assertEquals("topic2", topic2.getName());
+    assertEquals("/mnt/thrift_logger", topic2.getLogDir());
   }
 
   Map<String, String> makeWrongSingerConfigProperties(int propertyNum) {
@@ -183,6 +186,7 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
         put("singer.logConfigDir", logConfigDir.getPath());
         put("singer.logConfigPollIntervalSecs", "1");
         put("singer.logRetentionInSecs", "172800");
+        put("singer.heartbeatEnabled", "false");
       }
     };
   }

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -25,6 +25,7 @@ import com.pinterest.singer.common.LogStreamWriter;
 import com.pinterest.singer.common.errors.LogStreamWriterException;
 import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.config.Decider;
 import com.pinterest.singer.monitor.LogStreamManager;
 import com.pinterest.singer.reader.DefaultLogStreamReader;
 import com.pinterest.singer.reader.ThriftLogFileReaderFactory;
@@ -38,6 +39,7 @@ import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
 import com.pinterest.singer.utils.SimpleThriftLogger;
 import com.pinterest.singer.utils.WatermarkUtils;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.Test;
@@ -269,7 +271,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
               new ThriftLogFileReaderFactory(new ThriftReaderConfig(16000, 16000))),
           writer,
           50, 1, 1, 3600, 1800);
-
+      Decider.setInstance(ImmutableMap.of("singer_test_decider", 0));
       // Write messages to be skipped.
       boolean deciderEnabled = processor.isLoggingAllowedByDecider();
       assertEquals(false, deciderEnabled);


### PR DESCRIPTION
(1) fix testProcessLogStreamWithDecider in DefaultLogStreamProcessorTest.java :
The decider instance needs to reset to pass the test

(2) fix testConfiguratorLoadConfigsAndReceiveLiveChanges in DirectorySingerConfiguratorTest.java :
set property "writer.kafka.producerConfig.bootstrap.servers" to "127.0.0.1:9092", then SingerConfig can be loaded without checking "writer.kafka.producerConfig.broker.serverset" during unit test. However "writer.kafka.producerConfig.broker.serverset" should be used in production and it can tell Singer to discover kafka cluster.

(3) fix testLoadNewConfig in DirectorySingerConfiguratorTest.java :
modify SingerTestBase.java to have correct property setup for topic1 and topic2. With these changes, fixing testLoadNewConfig is straightforward.