### PR TITLE
Implement MissingDirChecker

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
@@ -32,6 +32,23 @@ public class SingerLog {
     this.singerLogConfig = Preconditions.checkNotNull(singerLogConfig);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SingerLog singerLog = (SingerLog) o;
+    return singerLogConfig.equals(singerLog.singerLogConfig);
+  }
+
+  @Override
+  public int hashCode() {
+    return singerLogConfig.hashCode();
+  }
+
   /**
    * @return the name of this SingerLog.
    */

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -98,5 +98,7 @@ public class SingerMetrics {
   public static final String DISABLE_SINGER_OSTRICH = "DISABLE_OSTRICH_METRICS";
   public static final String LEADER_INFO_EXCEPTION = SINGER_WRITER + "leader_info_exception";
   public static final String MISSING_LOCAL_PARTITIONS = "singer.locality.missing_local_partitions";
+  public static final String MISSING_DIR_CHECKER_INTERRUPTED = "singer.missing_dir_checker.thread_interrupted";
+  public static final String NUMBER_OF_MISSING_DIRS = "singer.missing_dir_checker.num_of_missing_dirs";
   
 }

--- a/singer/src/main/java/com/pinterest/singer/monitor/MissingDirChecker.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/MissingDirChecker.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.monitor;
+
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.common.errors.SingerLogException;
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.twitter.ostrich.stats.Stats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * MissingDirChecker is a daemon thread that get initialized, started and stopped in
+ * LogStreamManager.  When LogStreamManager tries to create LogStreams for each SingerLog, if the
+ * corresponding log directory (eg: /mnt/thrift_logger/) has not been created yet, the SingerLog
+ * will be put to a HashMap named singerLogsWithoutDir. MissingDirChecker will run every
+ * sleepInMills (eg: 20000 milliseconds) and check if the log directory for this SingerLog has
+ * been created. Once log directory has been created, LogStreamManager.initializeLogStreams method
+ * will be called for this SingerLog and SingerLog will be removed from singerLogsWithoutDir if
+ * the method call does not throw any exception.
+ *
+ */
+public class MissingDirChecker implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MissingDirChecker.class);
+
+  private long sleepInMills = 20000L;
+  private AtomicBoolean cancelled = new AtomicBoolean(false);
+  private Map<SingerLog, String> singerLogsWithoutDir;
+  private Thread thread;
+
+  @VisibleForTesting
+  public AtomicBoolean getCancelled() {
+    return cancelled;
+  }
+
+  @VisibleForTesting
+  public long getSleepInMills() {
+    return sleepInMills;
+  }
+
+  @VisibleForTesting
+  public void setSleepInMills(long sleepInMills) {
+    this.sleepInMills = sleepInMills;
+  }
+
+  @VisibleForTesting
+  public Map<SingerLog, String> getSingerLogsWithoutDir() {
+    return singerLogsWithoutDir;
+  }
+
+  public void setSingerLogsWithoutDir(Map<SingerLog, String> singerLogsWithoutDir) {
+    this.singerLogsWithoutDir = singerLogsWithoutDir;
+  }
+
+  @Override
+  public void run() {
+    LOG.info("[{}] is checking missing directories if any...", Thread.currentThread().getName());
+    try {
+      while (!cancelled.get() && singerLogsWithoutDir != null && singerLogsWithoutDir.size() >0) {
+        LOG.info("[{}] found {} singerLogs without directory",
+            Thread.currentThread().getName(), singerLogsWithoutDir.size());
+        Iterator<Map.Entry<SingerLog, String>> iterator = singerLogsWithoutDir.entrySet().iterator();
+        while (iterator.hasNext()) {
+          Map.Entry<SingerLog, String> entry = iterator.next();
+          SingerLog singerLog = entry.getKey();
+          String podUid = entry.getValue();
+          SingerLogConfig singerLogConfig = singerLog.getSingerLogConfig();
+          String logDir = singerLogConfig.getLogDir();
+          File dir = new File(logDir);
+          // if dir has been created, method initializeLogStreams will be called for this SingerLog.
+          // This SingerLog will be removed once method call throws no exception.
+          if (dir.exists()) {
+            try {
+              LogStreamManager.initializeLogStreams(singerLog, podUid);
+              iterator.remove();
+              Stats.setGauge(SingerMetrics.NUMBER_OF_MISSING_DIRS,  singerLogsWithoutDir.size());
+              LOG.info("[{}] after {} created, log stream is initialized for {}.",
+                  Thread.currentThread().getName(), dir.getAbsoluteFile(), singerLog.getLogName());
+            } catch (SingerLogException e) {
+              LOG.warn("Exception thrown while initializing log streams ", e);
+            }
+          }
+        }
+        LOG.info("[{}] sleep for {} milliseconds and then check again.",
+            Thread.currentThread().getName(), sleepInMills);
+        Thread.sleep(sleepInMills);
+      }
+    } catch (InterruptedException e){
+      Stats.incr(SingerMetrics.MISSING_DIR_CHECKER_INTERRUPTED);
+      LOG.warn("MissingDirChecker thread is interrupted ", e);
+    } catch (Exception e){
+      LOG.error("MissingDirChecker thread needs to stop due to ", e);
+    } finally {
+      LOG.info("MissingDirChecker thread stopped. SingerLogs without dir: " + singerLogsWithoutDir);
+    }
+  }
+
+  public synchronized void start() {
+    if(this.thread == null) {
+      thread = new Thread(this);
+      thread.setDaemon(true);
+      thread.setName("MissingDirChecker");
+      thread.start();
+    }
+  }
+
+  public synchronized void stop(){
+    cancelled.set(true);
+    if(this.thread != null && thread.isAlive()) {
+      thread.interrupt();
+    }
+  }
+
+}

--- a/singer/src/test/java/com/pinterest/singer/monitor/MissingDirCheckerTest.java
+++ b/singer/src/test/java/com/pinterest/singer/monitor/MissingDirCheckerTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.monitor;
+
+import com.pinterest.singer.SingerTestBase;
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.config.DirectorySingerConfigurator;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+
+public class MissingDirCheckerTest extends SingerTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MissingDirCheckerTest.class);
+
+  @Before
+  public void setUp() throws SecurityException, NoSuchFieldException, IllegalArgumentException,
+                             IllegalAccessException, IOException {
+    tempDir.create();
+    logConfigDir = tempDir.newFolder(DirectorySingerConfigurator.SINGER_LOG_CONFIG_DIR);
+
+    LOG.info("Get and reset LogStreamManager instance (singleton) to make sure that instance used"
+        + " in unit test is specifically set for this unit test");
+    LogStreamManager.getInstance();
+    LogStreamManager.reset();
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    File testBaseDir= tempDir.getRoot();
+    LOG.info("Clean up files under test base dir: " + testBaseDir.getAbsolutePath());
+    if (testBaseDir.exists()) {
+      FileUtils.deleteDirectory(testBaseDir);
+    }
+  }
+
+  /**
+   *  This test is to verify MissingDirChecker can track all SingerLog whose log dir was not
+   *  created before Singer is started. After log dir for certain SingerLog was created,
+   *  MissingDirChecker will call method to properly initialize log stream for this SingerLog and
+   *  remove this SingerLog from the tracking hash map maintained by MissingDirChecker.
+   *
+   *  If this test fails, it might be the issue that after log dir was created for certain
+   *  SingerLog, MissingDirChecker has not had chance to call method to initialize log stream and
+   *  remove this SingerLog from the hash map. One fix is to let the Thread sleep longer, eg:
+   *  Thread.sleep(instance.getMissingDirChecker().getSleepInMills() * 5);
+   * @throws Exception
+   */
+  @Test
+  public void testMissingDirChecker() throws Exception{
+    String testBasePath = tempDir.getRoot().getAbsolutePath();
+
+    LOG.info("Create test singer property file and singer log config property file.");
+    Map<String, String> singerConfigProperties = makeDirectorySingerConfigProperties("");
+    File singerConfigFile = createSingerConfigFile(singerConfigProperties);
+    String[] propertyFileNames = {"test.app1.properties",  "test.app2.properties",
+                                  "test.app3.properties", "test.app4.properties",};
+    String[] logStreamRegexes = {"app1_(\\\\w+)", "app2_(\\\\w+)", "app3_(\\\\w+)", "app4_(\\\\w+)"};
+    String[] logDirPaths ={"/mnt/log/singer/", "/mnt/thrift_logger/", "/x/y/z/", "/a/b/c"};
+    String[] topicNames = {"topic1", "topic2", "topic3", "topic4"};
+    File[] files = new File[logDirPaths.length];
+    for(int i = 0; i < logDirPaths.length; i++) {
+      logDirPaths[i] = new File(testBasePath, logDirPaths[i]).getAbsolutePath();
+      files[i] = createSingerLogConfigPropertyFile(propertyFileNames[i], logStreamRegexes[i],
+          logDirPaths[i], topicNames[i]);
+    }
+
+    LOG.info("Try to parse SingerConfig.");
+    String parentDirPath = singerConfigFile.getParent();
+    DirectorySingerConfigurator configurator = new DirectorySingerConfigurator(parentDirPath);
+    SingerConfig singerConfig = configurator.parseSingerConfig();
+
+    LOG.info("Create LogStreamManager instance (Singleton).");
+    SingerSettings.setSingerConfig(singerConfig);
+    LogStreamManager instance = LogStreamManager.getInstance();
+    LogStreamManager.initializeLogStreams();
+
+    // setting sleep time of MissingDirChecker to be 5 seconds in order to accelerate unit test.
+    instance.getMissingDirChecker().setSleepInMills(5000);
+
+    int numOfSingerLogsWithoutDir = logDirPaths.length;
+    assertEquals(numOfSingerLogsWithoutDir, instance.getMissingDirChecker().getSingerLogsWithoutDir().size());
+
+    LOG.info("Verify MissingDirChecker runs properly while logDir is created for each SingerLog");
+    for(String path : logDirPaths) {
+      File f1 = new File(path);
+      f1.mkdirs();
+      assertTrue(f1.exists() && f1.isDirectory());
+      Thread.sleep(instance.getMissingDirChecker().getSleepInMills() * 2);
+      numOfSingerLogsWithoutDir -= 1;
+      LOG.info("verify the number match: {} {}", numOfSingerLogsWithoutDir,
+          instance.getMissingDirChecker().getSingerLogsWithoutDir().size());
+      assertEquals(numOfSingerLogsWithoutDir, instance.getMissingDirChecker().getSingerLogsWithoutDir().size());
+    }
+    LOG.info("Verify MissingDirChecker thread can be stopped properly.");
+    assertFalse(instance.getMissingDirChecker().getCancelled().get());
+    instance.stop();
+    assertTrue(instance.getMissingDirChecker().getCancelled().get());
+
+  }
+
+  public Map<String, String> makeDirectorySingerConfigProperties(String logConfigDirPath) {
+    return new TreeMap<String, String>() {
+      {
+        put("singer.threadPoolSize", "8");
+        put("singer.ostrichPort", "9896");
+        put("singer.monitor.monitorIntervalInSecs", "10");
+        put("singer.logConfigDir", logConfigDir.getPath());
+        put("singer.logConfigPollIntervalSecs", "1");
+        put("singer.logRetentionInSecs", "172800");
+        put("singer.heartbeatEnabled", "false");
+      }
+    };
+  }
+
+  public File createSingerLogConfigPropertyFile(String propertyFileName,
+                                                String logStreamRegex,
+                                                String logDirPath,
+                                                String topicName) throws IOException{
+    Map<String, String> override = new HashMap<String, String>();
+    override.put("writer.kafka.producerConfig.bootstrap.servers", "127.0.0.1:9092");
+    override.put("logDir", logDirPath);
+    override.put("logStreamRegex", logStreamRegex);
+    override.put("writer.kafka.topic", topicName);
+    return  createLogConfigPropertiesFile(propertyFileName, override);
+  }
+
+}
+
+


### PR DESCRIPTION
MissingDirChecker is a daemon thread that get initialized, started and stopped in LogStreamManager.  When LogStreamManager tries to create LogStreams for each SingerLog, if the corresponding log directory (eg: /mnt/thrift_logger/) has not been created yet, the SingerLog will be put to a HashMap named singerLogsWithoutDir. MissingDirChecker will run every sleep_in_milliseconds (eg: 20 seconds) to check if the log directory for this SingerLog has been created. Once log directory has been created, LogStreamManager.initializeLogStreams method will be called for this SingerLog and SingerLog  will be removed from singerLogsWithoutDir if the method call does not throw any exception.