### PR TITLE
 Enables Singer to extract LoggingAuditHeaders from LogMessage and attach to the Headers of ProducerRecord

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -187,6 +187,12 @@ struct SingerLogConfig {
    * Default value is -1 that means that there is no log retention enforcement by Singer.
    */
   9: optional i32 logRetentionInSeconds = -1;
+  10: optional bool enableHeadersInjector = false;
+  /**
+   * headers injector class
+   */
+  11: optional string headersInjectorClass = "com.pinterest.singer.writer.headersinjectors.LoggingAuditHeadersInjector";
+
 }
 
 /**
@@ -329,5 +335,5 @@ struct SingerConfig {
    * Singer Environment provider class
    */
   18: optional string environmentProviderClass;
-  
+
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -100,5 +100,6 @@ public class SingerMetrics {
   public static final String MISSING_LOCAL_PARTITIONS = "singer.locality.missing_local_partitions";
   public static final String MISSING_DIR_CHECKER_INTERRUPTED = "singer.missing_dir_checker.thread_interrupted";
   public static final String NUMBER_OF_MISSING_DIRS = "singer.missing_dir_checker.num_of_missing_dirs";
+  public static final String NUMBER_OF_SERIALIZING_HEADERS_ERRORS = "singer.headers_injector.num_of_serializing_headers_errors";
   
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
@@ -25,6 +25,7 @@ import com.pinterest.singer.monitor.FileSystemMonitor;
 import com.pinterest.singer.monitor.LogStreamManager;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+
 import com.twitter.ostrich.stats.Stats;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -319,4 +320,5 @@ public final class SingerSettings {
   public static void setEnvironment(Environment environment) {
     SingerSettings.environment = environment;
   }
+
 }

--- a/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
@@ -334,10 +334,12 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
 
     int writeTimeoutInSeconds = kafkaWriterConfig.getWriteTimeoutInSeconds();
     String partitionerClass = producerConfig.getPartitionerClass();
+    boolean enableHeadersInjector = logStream.getSingerLog().getSingerLogConfig().isEnableHeadersInjector();
+
     try {
       KafkaWriter kafkaWriter =
           new KafkaWriter(logStream, producerConfig, topic, kafkaWriterConfig.isSkipNoLeaderPartitions(),
-              auditingEnabled, auditTopic, partitionerClass, writeTimeoutInSeconds);
+              auditingEnabled, auditTopic, partitionerClass, writeTimeoutInSeconds, enableHeadersInjector);
       LOG.info("Created kafka writer : " + kafkaWriterConfig.toString());
       return kafkaWriter;
     } catch (Exception e) {

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -42,6 +42,8 @@ import com.pinterest.singer.thrift.configuration.TextLogMessageType;
 import com.pinterest.singer.thrift.configuration.TextReaderConfig;
 import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
 import com.pinterest.singer.thrift.configuration.WriterType;
+import com.pinterest.singer.writer.HeadersInjector;
+
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -348,6 +350,13 @@ public class LogConfigUtils {
     SingerLogConfig config = new SingerLogConfig(logName, local_dir, logfile_regex, processorConfig,
         readerConfig, writerConfig);
     config.setLogDecider(logDecider);
+    if (logConfiguration.containsKey("enableHeadersInjector")){
+      boolean enableHeadersInjector = logConfiguration.getBoolean("enableHeadersInjector");
+      config.setEnableHeadersInjector(enableHeadersInjector);
+      if (enableHeadersInjector && logConfiguration.containsKey("headersInjectorClass")){
+        config.setHeadersInjectorClass(logConfiguration.getString("headersInjectorClass"));
+      }
+    }
 
     FileNameMatchMode matchMode = FileNameMatchMode.PREFIX;
     String matchModeStr = logConfiguration.getString("logFileMatchMode");
@@ -365,6 +374,7 @@ public class LogConfigUtils {
       config
           .setLogRetentionInSeconds(logConfiguration.getInt(SingerConfigDef.LOG_RETENTION_SECONDS));
     }
+
     return config;
   }
 

--- a/singer/src/main/java/com/pinterest/singer/writer/HeadersInjector.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/HeadersInjector.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer;
+
+import com.pinterest.singer.thrift.LogMessage;
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * Interface to add headers to ProducerRecord's Headers object. Concrete implementations of this
+ * interface could chain their addHeaders(Headers headers, LogMessage logMessage) method to modify
+ * the original ProducerRecord's Headers object.
+ */
+public interface HeadersInjector {
+
+  /**
+   * Given ProducerRecord's Headers object and LogMessage object
+   *
+   * @return The original ProducerRecord's Headers object with some headers added.
+   */
+
+   Headers addHeaders(Headers headers, LogMessage logMessage);
+
+}

--- a/singer/src/main/java/com/pinterest/singer/writer/headersinjectors/LoggingAuditHeadersInjector.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/headersinjectors/LoggingAuditHeadersInjector.java
@@ -1,0 +1,40 @@
+package com.pinterest.singer.writer.headersinjectors;
+
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.writer.HeadersInjector;
+
+import com.twitter.ostrich.stats.Stats;
+import org.apache.kafka.common.header.Headers;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * LoggingAuditHeadersInjector can extract LoggingAuditHeaders from LogMessage and inject this
+ * this object as the headers of ProducerRecord's Headers.
+ */
+public class LoggingAuditHeadersInjector implements HeadersInjector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoggingAuditHeadersInjector.class);
+
+  private static final String HEADER_KEY = "loggingAuditHeaders";
+  private static final TSerializer SER = new TSerializer();
+
+  public static String getHeaderKey() {
+    return HEADER_KEY;
+  }
+
+  @Override
+  public Headers addHeaders(Headers headers, LogMessage logMessage) {
+    try {
+      headers.add(HEADER_KEY, SER.serialize(logMessage.getLoggingAuditHeaders()));
+    } catch (TException e) {
+      Stats.incr(SingerMetrics.NUMBER_OF_SERIALIZING_HEADERS_ERRORS);
+      LOG.warn("Exception thrown while serializing loggingAuditHeaders", e);
+    } finally {
+      return headers;
+    }
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/TestKafkaWriter.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/TestKafkaWriter.java
@@ -1,5 +1,6 @@
 package com.pinterest.singer.writer;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -11,6 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.Executors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -19,7 +21,9 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.pulsar.shade.org.apache.commons.lang3.concurrent.ConcurrentUtils;
+import org.apache.thrift.TSerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -28,13 +32,19 @@ import org.mockito.runners.MockitoJUnitRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+
+import com.pinterest.singer.SingerTestBase;
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.loggingaudit.thrift.LoggingAuditHeaders;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
+import com.pinterest.singer.writer.headersinjectors.LoggingAuditHeadersInjector;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestKafkaWriter {
+public class TestKafkaWriter extends SingerTestBase {
 
   private static final int NUM_EVENTS = 1000;
   @Mock
@@ -104,4 +114,102 @@ public class TestKafkaWriter {
     writer.close();
   }
 
+  @Test
+  public void testWriterWithHeadersInjectorEnabledWithWrongClass() throws Exception {
+    SingerLog singerLog = new SingerLog(createSingerLogConfig("test", "/a/b/c"));
+    LogStream logStream = new LogStream(singerLog, "test.tmp");
+    KafkaMessagePartitioner partitioner = new Crc32ByteArrayPartitioner();
+    KafkaProducerConfig config = new KafkaProducerConfig();
+    SingerSettings.setSingerConfig(new SingerConfig());
+    KafkaProducerManager.injectTestProducer(config, producer);
+    // set wrong headerInjectorClass name, headerInjector will be null if enableHeaderInjector is true
+    logStream.getSingerLog().getSingerLogConfig().setHeadersInjectorClass("com.pinterest.x.y.z");
+    KafkaWriter writer = new KafkaWriter(logStream, config, partitioner, "topicx", false,
+        Executors.newCachedThreadPool(), true);
+    assertNull(writer.getHeadersInjector());
+  }
+
+    @Test
+  public void testWriterWithHeadersInjectorEnabled() throws Exception {
+    SingerLog singerLog = new SingerLog(createSingerLogConfig("test", "/a/b/c"));
+    LogStream logStream = new LogStream(singerLog, "test.tmp");
+    KafkaMessagePartitioner partitioner = new Crc32ByteArrayPartitioner();
+    KafkaProducerConfig config = new KafkaProducerConfig();
+    SingerSettings.setSingerConfig(new SingerConfig());
+    KafkaProducerManager.injectTestProducer(config, producer);
+    KafkaWriter writer = new KafkaWriter(logStream, config, partitioner, "topicx", false,
+        Executors.newCachedThreadPool(), true);
+    List<PartitionInfo> partitions = ImmutableList.copyOf(Arrays.asList(
+        new PartitionInfo("topicx", 1, new Node(2, "broker2", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 0, new Node(1, "broker1", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 2, new Node(3, "broker3", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topicx", 6, new Node(2, "broker2", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 3, new Node(4, "broker4", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 5, new Node(1, "broker1", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 7, new Node(3, "broker3", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topicx", 4, new Node(5, "broker5", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 8, new Node(4, "broker4", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 9, new Node(5, "broker5", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 10, new Node(1, "broker1", 9092, "us-east-1a"), null, null)));
+    when(producer.partitionsFor("topicx")).thenReturn(partitions);
+    when(producer.send(any())).thenReturn(ConcurrentUtils.constantFuture(
+        new RecordMetadata(new TopicPartition("topicx", 0), 0L, 0L, 0L, 0L, 0, 0)));
+
+    Map<Integer, List<LogMessage>> msgPartitionMap = new HashMap<>();
+    HashFunction crc32 = Hashing.crc32();
+    List<LogMessage> logMessages = new ArrayList<>();
+    int pid = new Random().nextInt();
+    long session = System.currentTimeMillis();
+    TSerializer serializer = new TSerializer();
+
+    for (int i = 0; i < NUM_EVENTS; i++) {
+      LogMessage logMessage = new LogMessage();
+      logMessage.setKey(ByteBuffer.allocate(100).put(String.valueOf(i).getBytes()));
+      logMessage.setMessage(ByteBuffer.allocate(100).put(String.valueOf(i).getBytes()));
+      LoggingAuditHeaders headers = new LoggingAuditHeaders()
+          .setHost("host-name")
+          .setTopic("topicx")
+          .setPid(pid)
+          .setSession(session)
+          .setLogSeqNumInSession(i);
+      logMessage.setLoggingAuditHeaders(headers);
+      logMessages.add(logMessage);
+
+      int partitionId = Math.abs(crc32.hashBytes(logMessage.getKey()).asInt() % partitions.size());
+      List<LogMessage> list = msgPartitionMap.get(partitionId);
+      if (list == null) {
+        list = new ArrayList<>();
+        msgPartitionMap.put(partitionId, list);
+      }
+      list.add(logMessage);
+    }
+
+    List<List<ProducerRecord<byte[], byte[]>>> messageCollation = writer
+        .messageCollation(partitions, "topicx", logMessages);
+    for (int i = 0; i < messageCollation.size(); i++) {
+      List<ProducerRecord<byte[], byte[]>> writerOutput = messageCollation.get(i);
+      List<LogMessage> originalData = msgPartitionMap.get(i);
+      if (originalData == null) {
+        assertEquals(0, writerOutput.size());
+        continue;
+      }
+      assertEquals(originalData.size(), writerOutput.size());
+      for (int j = 0; j < writerOutput.size(); j++) {
+        assertTrue(Arrays.equals(originalData.get(j).getKey(), writerOutput.get(j).key()));
+        boolean foundLoggingAuditHeaders = false;
+        for(Header header : writerOutput.get(j).headers().toArray()){
+          if (header.key().equals(LoggingAuditHeadersInjector.getHeaderKey())){
+            byte[] expected = serializer.serialize(originalData.get(j).getLoggingAuditHeaders());
+            assertArrayEquals(expected, header.value());
+            foundLoggingAuditHeaders = true;
+            break;
+          }
+        }
+        assertTrue(foundLoggingAuditHeaders);
+      }
+    }
+    // validate if writes are throwing any error
+    writer.writeLogMessages(logMessages);
+    writer.close();
+  }
 }


### PR DESCRIPTION
This PR is about:

(1) add HeadersProvider interface and LoggingAuditHeadersProvider implementation;
(2) make headersProviderClass an option for SingerConfig (similar to environmentProviderClass);
(3) make enableHeadersProvider an option for SingerLogConfig to allow per topic configuration;
(4) modify KafkaWriter.java to attach LoggingAuditHeaders if configured properly.