### PR TITLE
Add support injection of Pod Uid instead of hostname for text logger

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
@@ -27,8 +27,14 @@ public class SingerLog {
 
   // The config for the SingerLog.
   private final SingerLogConfig singerLogConfig;
+  private String podUid;
 
   public SingerLog(SingerLogConfig singerLogConfig) {
+    this.singerLogConfig = Preconditions.checkNotNull(singerLogConfig);
+  }
+
+  public SingerLog(SingerLogConfig singerLogConfig, String podUid) {
+    this.podUid = podUid;
     this.singerLogConfig = Preconditions.checkNotNull(singerLogConfig);
   }
 
@@ -61,5 +67,9 @@ public class SingerLog {
    */
   public SingerLogConfig getSingerLogConfig() {
     return singerLogConfig;
+  }
+  
+  public String getPodUid() {
+    return podUid;
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
@@ -636,7 +636,7 @@ public class LogStreamManager implements PodWatcher {
           // since the DefaultLogMonitor de-duplicates this using hashcode
           // which is dependent on LogStream name
           clone.setName(podUid + ":" + clone.getName());
-          singerLog = new SingerLog(clone);
+          singerLog = new SingerLog(clone, podUid);
 
           if (!singerLogPaths.containsKey(logPathKey)) {
             singerLogPaths.put(logPathKey, new HashSet<>());

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 public class TextLogFileReader implements LogFileReader {
 
   private static final Logger LOG = LoggerFactory.getLogger(TextLogFileReader.class);
-  private static final String HOSTNAME = SingerUtils.getHostname();
 
   protected boolean closed;
   private final LogFile logFile;
@@ -55,6 +54,8 @@ public class TextLogFileReader implements LogFileReader {
   // The text log message format, can be TextMessage, or String;
   private final TextLogMessageType textLogMessageType;
 
+  private String hostname;
+
   public TextLogFileReader(
       LogFile logFile,
       String path,
@@ -66,10 +67,12 @@ public class TextLogFileReader implements LogFileReader {
       TextLogMessageType messageType,
       boolean prependTimestamp,
       boolean prependHostName,
+      String hostname,
       String prependFieldDelimiter) throws Exception {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(path));
     Preconditions.checkArgument(byteOffset >= 0);
 
+    this.hostname = hostname;
     this.logFile = Preconditions.checkNotNull(logFile);
     this.path = path;
     this.numMessagesPerLogMessage = numMessagesPerLogMessage;
@@ -118,7 +121,7 @@ public class TextLogFileReader implements LogFileReader {
           prependStr += System.currentTimeMillis() + prependFieldDelimiter;
         }
         if (prependHostname) {
-          prependStr += HOSTNAME + prependFieldDelimiter;
+          prependStr += hostname + prependFieldDelimiter;
         }
         if (prependStr.length() > 0) {
           maxBuffer.put(prependStr.getBytes());
@@ -142,7 +145,7 @@ public class TextLogFileReader implements LogFileReader {
       case THRIFT_TEXT_MESSAGE:
         TextMessage textMessage = new TextMessage();
         textMessage.setFilename(path);
-        textMessage.setHost(HOSTNAME);
+        textMessage.setHost(hostname);
         textMessage.addToMessages(TextMessageReader.bufToString(out));
         logMessage = new LogMessage(ByteBuffer.wrap(serializer.serialize(textMessage)));
         break;

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.reader;
 
 import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.configuration.TextReaderConfig;
 import com.pinterest.singer.utils.LogFileUtils;
@@ -40,9 +41,9 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
     this.readerConfig = Preconditions.checkNotNull(readerConfig);
   }
 
+  @SuppressWarnings("resource")
   public LogFileReader getLogFileReader(
       LogStream logStream, LogFile logFile, String path, long byteOffset) throws Exception {
-
     LogFileReader reader;
     try {
       long inode = SingerUtils.getFileInode(FileSystems.getDefault().getPath(path));
@@ -60,6 +61,7 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
           readerConfig.getTextLogMessageType(),
           readerConfig.isPrependTimestamp(),
           readerConfig.isPrependHostname(),
+          SingerUtils.getHostNameBasedOnConfig(logStream, SingerSettings.getSingerConfig()),
           readerConfig.getPrependFieldDelimiter());
     } catch (LogFileReaderException e) {
       LOG.warn("Exception in getLogFileReader", e);

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -15,6 +15,7 @@
  */
 package com.pinterest.singer.utils;
 
+import com.pinterest.singer.common.LogStream;
 import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.config.DirectorySingerConfigurator;
 import com.pinterest.singer.config.PropertyFileSingerConfigurator;
@@ -22,12 +23,13 @@ import com.pinterest.singer.config.SingerConfigurator;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 
 import com.pinterest.singer.config.SingerDirectoryWatcher;
-
+import com.pinterest.singer.monitor.LogStreamManager;
 import com.google.common.base.Preconditions;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
+import java.util.Arrays;
 import java.util.Comparator;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.comparator.LastModifiedFileComparator;
@@ -108,11 +110,7 @@ public class SingerUtils {
   }
   
   public static void printStackTrace() {
-	  StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
-	  for(StackTraceElement e:stackTraceElements) {
-		  System.out.println(e.getClassName()+"."+e.getMethodName()+":"+e.getLineNumber());
-	  }
-	  System.out.println();
+	  LOG.warn(Arrays.toString(Thread.currentThread().getStackTrace()));
   }
 
   /**
@@ -300,4 +298,16 @@ public class SingerUtils {
           throw new IOException(e);
       }
   }
+
+  public static String getHostNameBasedOnConfig(LogStream logStream,
+                                                     SingerConfig singerConfig) {
+    if (singerConfig.isKubernetesEnabled()) {
+      if (logStream.getSingerLog().getPodUid() !=null 
+          && logStream.getSingerLog().getPodUid() != LogStreamManager.NON_KUBERNETES_POD_ID) {
+        return logStream.getSingerLog().getPodUid();
+      }
+    }
+    return SingerUtils.getHostname();
+  }
+  
 }

--- a/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
@@ -43,14 +43,32 @@ public class TestTextLogFileReader extends SingerTestBase {
     long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
     LogFile logFile = new LogFile(inode);
     LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 1,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null);
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null, null);
     for (int i = 0; i < 100; i++) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
       assertEquals(dataWritten.get(i), new String(log.getLogMessage().getMessage()));
     }
     reader.close();
   }
+  
+  @Test
+  public void testReadLogMessageAndPositionWithHostname() throws Exception {
+    String path = FilenameUtils.concat(getTempPath(), "test2.log");
+    List<String> dataWritten = generateDummyMessagesToFile(path);
+    String delimiter = " ";
+    String hostname = "test";
 
+    long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
+    LogFile logFile = new LogFile(inode);
+    LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 1,
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, true, hostname, delimiter);
+    for (int i = 0; i < 100; i++) {
+      LogMessageAndPosition log = reader.readLogMessageAndPosition();
+      assertEquals(hostname + delimiter + dataWritten.get(i), new String(log.getLogMessage().getMessage()));
+    }
+    reader.close();
+  }
+  
   @Test
   public void testReadLogMessageAndPositionMultiRead() throws Exception {
     String path = FilenameUtils.concat(getTempPath(), "test2.log");
@@ -59,7 +77,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
     LogFile logFile = new LogFile(inode);
     LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 2,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null);
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null, null);
     for (int i = 0; i < 100; i = i + 2) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
       assertEquals(dataWritten.get(i) + dataWritten.get(i + 1),

--- a/singer/src/test/java/com/pinterest/singer/utils/TestSingerUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestSingerUtils.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.monitor.LogStreamManager;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+
+public class TestSingerUtils {
+
+  @Test
+  public void testGetHostNameBasedOnConfig() {
+    LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig(), "pod-11"), "test");
+    SingerConfig config = new SingerConfig();
+    config.setKubernetesEnabled(true);
+    // case 1 kubernetes enabled; pod id specified
+    String hostNameBasedOnConfig = SingerUtils.getHostNameBasedOnConfig(logStream, config);
+    assertEquals("pod-11", hostNameBasedOnConfig);
+    
+    // case 2 kubernetes enabled; pod id null
+    logStream = new LogStream(new SingerLog(new SingerLogConfig(), null), "test");
+    hostNameBasedOnConfig = SingerUtils.getHostNameBasedOnConfig(logStream, config);
+    assertEquals(SingerUtils.getHostname(), hostNameBasedOnConfig);
+    
+    // case 3 kubernetes enabled; pod id NON_KUBERNETES_POD_ID
+    logStream = new LogStream(new SingerLog(new SingerLogConfig(), LogStreamManager.NON_KUBERNETES_POD_ID), "test");
+    hostNameBasedOnConfig = SingerUtils.getHostNameBasedOnConfig(logStream, config);
+    assertEquals(SingerUtils.getHostname(), hostNameBasedOnConfig);
+    
+    // case 4 kubernetes disabled
+    config.setKubernetesEnabled(false);
+    logStream = new LogStream(new SingerLog(new SingerLogConfig(), "pod-11"), "test");
+    hostNameBasedOnConfig = SingerUtils.getHostNameBasedOnConfig(logStream, config);
+    assertEquals(SingerUtils.getHostname(), hostNameBasedOnConfig);
+  }
+
+}


### PR DESCRIPTION
Add support injection of Pod Uid instead of hostname for text logger. Logic:

If prepend hostname is enabled for text logger config & singer is running in Kubernetes mode then attempt to use pod id as hostname if pod if is NOT null or NON_KUBERNETES_POD_ID else return hostname.

```Results :

Tests run: 65, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Singer Logging Agent 0.7.3.29:
[INFO] 
[INFO] Singer Logging Agent ............................... SUCCESS [  0.138 s]
[INFO] thrift-logger ...................................... SUCCESS [  8.141 s]
[INFO] singer ............................................. SUCCESS [02:32 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:40 min
[INFO] Finished at: 2019-11-08T18:44:21Z
[INFO] ------------------------------------------------------------------------```