### PR TITLE
Null check in KafkaWriterTask

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaWritingTask.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaWritingTask.java
@@ -116,7 +116,7 @@ public class KafkaWritingTask implements Callable<KafkaWritingTaskResult> {
       OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_FAILURE, 1, "broker=" + leaderNode);
       result = new KafkaWritingTaskResult(false, e);
     } finally {
-      if (!result.success) {
+      if (result != null && !result.success) {
         for (Future<RecordMetadata> future : futures) {
           if (!future.isCancelled() && !future.isDone()) {
             future.cancel(true);


### PR DESCRIPTION
Currently if the call fails before result is populated, the finally block will fail due to NPE. Add a sanity check to avoid this.