### PR TITLE
[WIP] Mapped Thrift Reader implementation

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/reader/ByteOffsetInputStream.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ByteOffsetInputStream.java
@@ -26,7 +26,7 @@ import java.io.RandomAccessFile;
  * The byteOffset will be from the beginning of the file.
  * Note that the file can be appended as it is being read.
  */
-final class ByteOffsetInputStream extends BufferedInputStream {
+public final class ByteOffsetInputStream extends BufferedInputStream {
 
   private final RandomAccessFile randomAccessFile;
   // Byte offset of current read position.

--- a/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedFileTBinaryProtocol.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedFileTBinaryProtocol.java
@@ -1,0 +1,407 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.reader.thrift;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TList;
+import org.apache.thrift.protocol.TMap;
+import org.apache.thrift.protocol.TMessage;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolException;
+import org.apache.thrift.protocol.TSet;
+import org.apache.thrift.protocol.TStruct;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TTransport;
+
+/**
+ * SingerTBinaryProtocol is an implementation of TBinaryProtocol reading data
+ * from Memory Mapped File. The entire length of file is memory mapped using
+ * {@link FileChannel}. This only creates a memory mapping however data will
+ * only be read when actual bytes are accessed so this is safe from a memory
+ * utilization. It's the responsibility of the underlying operating system to
+ * swap pages if sufficient memory is not available.
+ * 
+ * Note that {@link TTransport} can't be used in this case since the
+ * {@link TProtocol} needs direct reference to the ByteBuffer for lower level
+ * byte manipulations which won't be possible without direct reference.
+ */
+public class MappedFileTBinaryProtocol extends TProtocol {
+
+  private static final Logger logger = Logger
+      .getLogger(MappedFileTBinaryProtocol.class.getCanonicalName());
+  private static final TStruct ANONYMOUS_STRUCT = new TStruct();
+  private static final long NO_LENGTH_LIMIT = -1;
+
+  protected static final int VERSION_MASK = 0xffff0000;
+  protected static final int VERSION_1 = 0x80010000;
+
+  /**
+   * The maximum number of bytes to read from the transport for variable-length
+   * fields (such as strings or binary) or {@link #NO_LENGTH_LIMIT} for unlimited.
+   */
+  private final long stringLengthLimit_;
+
+  /**
+   * The maximum number of elements to read from the network for containers (maps,
+   * sets, lists), or {@link #NO_LENGTH_LIMIT} for unlimited.
+   */
+  private final long containerLengthLimit_;
+
+  protected boolean strictRead_;
+  protected boolean strictWrite_;
+
+  private ByteBuffer buffer;
+  private File file;
+
+  public MappedFileTBinaryProtocol(File file) throws FileNotFoundException, IOException {
+    this(file, false, true);
+  }
+
+  public MappedFileTBinaryProtocol(File file,
+                                   boolean strictRead,
+                                   boolean strictWrite) throws FileNotFoundException, IOException {
+    this(file, NO_LENGTH_LIMIT, NO_LENGTH_LIMIT, strictRead, strictWrite);
+  }
+
+  public MappedFileTBinaryProtocol(File file,
+                                   long stringLengthLimit,
+                                   long containerLengthLimit) throws FileNotFoundException,
+                                                              IOException {
+    this(file, stringLengthLimit, containerLengthLimit, false, true);
+  }
+
+  public MappedFileTBinaryProtocol(File file,
+                                   long stringLengthLimit,
+                                   long containerLengthLimit,
+                                   boolean strictRead,
+                                   boolean strictWrite) throws FileNotFoundException, IOException {
+    super(null);
+    this.file = file;
+    buffer = mapFile(file);
+    stringLengthLimit_ = stringLengthLimit;
+    containerLengthLimit_ = containerLengthLimit;
+    strictRead_ = strictRead;
+    strictWrite_ = strictWrite;
+  }
+
+  /**
+   * Used to map (memorymapped file) and remap files. Note that file handle is
+   * closed immediately after mapping to not run out of file handles. Once we have
+   * the memorymap the file handle is no longer needed.
+   * 
+   * @param file
+   * @return
+   * @throws FileNotFoundException
+   * @throws IOException
+   */
+  protected ByteBuffer mapFile(File file) throws FileNotFoundException, IOException {
+    RandomAccessFile raf = new RandomAccessFile(file, "r");
+    MappedByteBuffer map = raf.getChannel().map(MapMode.READ_ONLY, 0, file.length());
+    raf.close();
+    return map;
+  }
+
+  /**
+   * Reading methods.
+   */
+
+  public TMessage readMessageBegin() throws TException {
+    int size = readI32();
+    if (size < 0) {
+      int version = size & VERSION_MASK;
+      if (version != VERSION_1) {
+        throw new TProtocolException(TProtocolException.BAD_VERSION,
+            "Bad version in readMessageBegin");
+      }
+      return new TMessage(readString(), (byte) (size & 0x000000ff), readI32());
+    } else {
+      if (strictRead_) {
+        throw new TProtocolException(TProtocolException.BAD_VERSION,
+            "Missing version in readMessageBegin");
+      }
+      return new TMessage(readStringBody(size), readByte(), readI32());
+    }
+  }
+
+  public void readMessageEnd() {
+  }
+
+  public TStruct readStructBegin() {
+    try {
+      // since data is framed, each message read is preceded by a 4 byte size
+      readI32();
+    } catch (TException e) {
+      logger.log(Level.SEVERE, "Failed to read frame", e);
+    }
+    return ANONYMOUS_STRUCT;
+  }
+
+  public void readStructEnd() {
+  }
+
+  public TField readFieldBegin() throws TException {
+    byte type = readByte();
+    short id = type == TType.STOP ? 0 : readI16();
+    return new TField("", type, id);
+  }
+
+  public void readFieldEnd() {
+  }
+
+  public TMap readMapBegin() throws TException {
+    TMap map = new TMap(readByte(), readByte(), readI32());
+    checkContainerReadLength(map.size);
+    return map;
+  }
+
+  public void readMapEnd() {
+  }
+
+  public TList readListBegin() throws TException {
+    TList list = new TList(readByte(), readI32());
+    checkContainerReadLength(list.size);
+    return list;
+  }
+
+  public void readListEnd() {
+  }
+
+  public TSet readSetBegin() throws TException {
+    TSet set = new TSet(readByte(), readI32());
+    checkContainerReadLength(set.size);
+    return set;
+  }
+
+  public void readSetEnd() {
+  }
+
+  public boolean readBool() throws TException {
+    return (readByte() == 1);
+  }
+
+  public byte readByte() throws TException {
+    checkAndMap(Byte.BYTES);
+    return buffer.get();
+  }
+
+  /**
+   * Checks if the specified number of bytes are available to be read from the
+   * byte buffer. If this is not true the method checks if the file has more data
+   * to be read and will trigger a remap of the file.
+   * 
+   * @param size
+   * @throws TException
+   */
+  protected void checkAndMap(int size) throws TException {
+    if (buffer.remaining() < size && buffer.limit() < file.length()) {
+      try {
+        int position = buffer.position();
+        buffer = mapFile(file);
+        buffer.position(position);
+      } catch (IOException e) {
+        throw new TException(e);
+      }
+    }
+  }
+
+  public short readI16() throws TException {
+    // (short) (((buf[off] & 0xff) << 8) | ((buf[off + 1] & 0xff)))
+    checkAndMap(Short.BYTES);
+    return buffer.getShort();
+  }
+
+  public int readI32() throws TException {
+//    ((buf[off] & 0xff) << 24) | ((buf[off + 1] & 0xff) << 16) | ((buf[off + 2] & 0xff) << 8)
+//        | ((buf[off + 3] & 0xff));
+    checkAndMap(Integer.BYTES);
+    return buffer.getInt();
+  }
+
+  public long readI64() throws TException {
+    /*
+     * ((long) (buf[off] & 0xff) << 56) | ((long) (buf[off + 1] & 0xff) << 48) |
+     * ((long) (buf[off + 2] & 0xff) << 40) | ((long) (buf[off + 3] & 0xff) << 32) |
+     * ((long) (buf[off + 4] & 0xff) << 24) | ((long) (buf[off + 5] & 0xff) << 16) |
+     * ((long) (buf[off + 6] & 0xff) << 8) | ((long) (buf[off + 7] & 0xff));
+     */
+    checkAndMap(Long.BYTES);
+    return buffer.getLong();
+  }
+
+  public double readDouble() throws TException {
+    return Double.longBitsToDouble(readI64());
+  }
+
+  public String readString() throws TException {
+    int size = readI32();
+    checkStringReadLength(size);
+    checkAndMap(size);
+    return readStringBody(size);
+  }
+
+  public String readStringBody(int size) throws TException {
+    checkStringReadLength(size);
+    try {
+      byte[] buf = new byte[size];
+      buffer.get(buf, 0, size);
+      return new String(buf, "UTF-8");
+    } catch (UnsupportedEncodingException uex) {
+      throw new TException("JVM DOES NOT SUPPORT UTF-8");
+    }
+  }
+
+  public ByteBuffer readBinary() throws TException {
+    int size = readI32();
+    checkStringReadLength(size);
+    checkAndMap(size);
+    int currentPosition = buffer.position();
+    ByteBuffer buf = buffer.slice();
+    buf.limit(size);
+    buffer.position(currentPosition + size);
+    return buf;
+  }
+
+  public void setByteOffset(int byteOffset) {
+    buffer.position(byteOffset);
+  }
+
+  private void checkStringReadLength(int length) throws TProtocolException {
+    if (length < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative length: " + length);
+    }
+    if (stringLengthLimit_ != NO_LENGTH_LIMIT && length > stringLengthLimit_) {
+      throw new TProtocolException(TProtocolException.SIZE_LIMIT,
+          "Length exceeded max allowed: " + length);
+    }
+  }
+
+  private void checkContainerReadLength(int length) throws TProtocolException {
+    if (length < 0) {
+      throw new TProtocolException(TProtocolException.NEGATIVE_SIZE, "Negative length: " + length);
+    }
+    if (containerLengthLimit_ != NO_LENGTH_LIMIT && length > containerLengthLimit_) {
+      throw new TProtocolException(TProtocolException.SIZE_LIMIT,
+          "Length exceeded max allowed: " + length);
+    }
+  }
+
+  public boolean isEOF() {
+    return !buffer.hasRemaining();
+  }
+
+  public int getBytesRemainingInBuffer() {
+    return buffer.remaining();
+  }
+
+  public int getByteOffset() {
+    return buffer.position();
+  }
+
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+
+  public void writeMessageBegin(TMessage message) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeMessageEnd() {
+  }
+
+  public void writeStructBegin(TStruct struct) {
+  }
+
+  public void writeStructEnd() {
+  }
+
+  public void writeFieldBegin(TField field) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeFieldEnd() {
+  }
+
+  public void writeFieldStop() throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeMapBegin(TMap map) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeMapEnd() {
+  }
+
+  public void writeListBegin(TList list) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeListEnd() {
+  }
+
+  public void writeSetBegin(TSet set) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeSetEnd() {
+  }
+
+  public void writeBool(boolean b) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeByte(byte b) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeI16(short i16) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeI32(int i32) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeI64(long i64) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeDouble(double dub) throws TException {
+    writeI64(Double.doubleToLongBits(dub));
+  }
+
+  public void writeString(String str) throws TException {
+    throw new TException("method not supported");
+  }
+
+  public void writeBinary(ByteBuffer bin) throws TException {
+    throw new TException("method not supported");
+  }
+
+}

--- a/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedThriftLogFileReader.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.reader.thrift;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.reader.LogFileReader;
+import com.pinterest.singer.reader.LogFileReaderException;
+import com.pinterest.singer.thrift.LogFile;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
+import com.pinterest.singer.thrift.LogPosition;
+import com.pinterest.singer.utils.SingerUtils;
+import com.twitter.ostrich.stats.Stats;
+
+/**
+ * Reader that reads from thrift LogFile.
+ * <p>
+ * This class is NOT thread-safe.
+ */
+public class MappedThriftLogFileReader implements LogFileReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MappedThriftLogFileReader.class);
+
+  // Factory that create LogMessage thrift objects.
+  private static final class LogMessageFactory
+      implements MappedThriftReader.TBaseFactory<com.pinterest.singer.thrift.LogMessage> {
+
+    public com.pinterest.singer.thrift.LogMessage get() {
+      return new com.pinterest.singer.thrift.LogMessage();
+    }
+  }
+
+  private final LogFile logFile;
+  private final String path;
+  private final MappedThriftReader<com.pinterest.singer.thrift.LogMessage> thriftReader;
+
+  /*
+   * The maximum message size that is defined in singer configuration file
+   */
+  private final int maxMessageSize;
+
+  /*
+   * To tolerate messsages that exceed the size limit and minimize data loss,
+   * Singer internally can read messages that 10 times larger than the specified
+   * size limit. For the messages that exceeds the size limit, Singer drops these
+   * messages and logs warnings, and do not send these messages to kafka.
+   */
+  private final int maxMessageSizeInternal;
+
+  protected boolean closed;
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public MappedThriftLogFileReader(LogFile logFile,
+                                   String path,
+                                   long byteOffset,
+                                   int readBufferSize,
+                                   int maxMessageSize) throws Exception {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(path));
+    Preconditions.checkArgument(byteOffset >= 0);
+
+    this.logFile = Preconditions.checkNotNull(logFile);
+    this.path = path;
+    this.maxMessageSize = maxMessageSize;
+    this.maxMessageSizeInternal = maxMessageSize * 10;
+
+    this.thriftReader = new MappedThriftReader(path, new LogMessageFactory(),
+        maxMessageSizeInternal);
+    this.thriftReader.setByteOffset((int) byteOffset);
+
+    // Make sure the path is still associated with the LogFile.
+    // This can happen when the path is reused for another LogFile during log
+    // rotation.
+    if (logFile.getInode() != SingerUtils.getFileInode(FileSystems.getDefault().getPath(path))) {
+      LOG.info("Log file {} does not match path: {}. The path has been reused for another file.",
+          logFile.getInode(), path);
+
+      // Close the reader and throw.
+      thriftReader.close();
+      throw new LogFileReaderException(
+          "Path: " + path + " is not associated with log file:" + logFile.toString());
+    }
+    closed = false;
+  }
+
+  @Override
+  public LogMessageAndPosition readLogMessageAndPosition() throws LogFileReaderException {
+    if (closed) {
+      throw new LogFileReaderException("Reader closed.");
+    }
+
+    try {
+      LogMessage logMessage = thriftReader.read();
+      while (logMessage != null) {
+        // Get the next LogMessage's byte offset
+        long newByteOffset = thriftReader.getByteOffset();
+        int messageSize = logMessage.getMessage().length;
+        if (messageSize > maxMessageSize) {
+          LOG.warn("Found a message at offset " + newByteOffset + "that exceeds the size limit in "
+              + logFile.toString() + ": messageSize =  " + messageSize);
+          OpenTsdbMetricConverter.incr("singer.thrift_reader.skip_message", 1, "path=" + path);
+          logMessage = thriftReader.read();
+        } else {
+          LogPosition position = new LogPosition(logFile, newByteOffset);
+          return new LogMessageAndPosition(logMessage, position);
+        }
+      }
+    } catch (TException e) {
+      LOG.error("Caught TException while reading " + logFile, e);
+      OpenTsdbMetricConverter.incr("singer.reader.exception.texception", 1, "path=" + path);
+      throw new LogFileReaderException("Cannot read a log message.", e);
+    } catch (Exception e) {
+      LOG.error("Caught exception when read a log message from log file: " + logFile, e);
+      Stats.incr("singer.reader.exception.unexpected");
+      throw new LogFileReaderException("Cannot read a log message.", e);
+    }
+    return null;
+  }
+
+  public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+
+    thriftReader.close();
+    closed = true;
+  }
+
+  @Override
+  public LogFile getLogFile() throws LogFileReaderException {
+    if (closed) {
+      throw new LogFileReaderException("Reader closed.");
+    }
+
+    return logFile;
+  }
+
+  @Override
+  public long getByteOffset() throws LogFileReaderException {
+    if (closed) {
+      throw new LogFileReaderException("Reader closed.");
+    }
+    try {
+      return thriftReader.getByteOffset();
+    } catch (Exception e) {
+      LOG.error("Caught exception when get reader byte offset of log file: " + logFile, e);
+      Stats.incr("singer.reader.exception.unexpected");
+      throw new LogFileReaderException("Can not get byte offset of the thrift reader", e);
+    }
+  }
+
+  @Override
+  public void setByteOffset(long byteOffset) throws LogFileReaderException {
+    if (closed) {
+      throw new LogFileReaderException("Reader closed.");
+    }
+    // TODO check overflow
+    try {
+      thriftReader.setByteOffset((int) byteOffset);
+    } catch (Exception e) {
+      LOG.error(String.format("Caught exception when set reader byte offset of log file: %s to: %d",
+          logFile, byteOffset), e);
+      Stats.incr("singer.reader.exception.unexpected");
+      throw new LogFileReaderException("Can not set byte offset on the thrift reader", e);
+    }
+  }
+
+  @Override
+  public boolean isClosed() {
+    return closed;
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedThriftReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/thrift/MappedThriftReader.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.reader.thrift;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TTransport;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+/**
+ * Reader that reads Thrift messages of thrift type from a file
+ * <p/>
+ * This class is NOT thread-safe.
+ */
+@SuppressWarnings("rawtypes")
+public class MappedThriftReader<T extends TBase> implements Closeable {
+
+  /**
+   * Factory that get a TBase instance of the thrift type to be read.
+   *
+   * @param <T> The thrift message type to be read.
+   */
+  public static interface TBaseFactory<T> {
+
+    T get();
+  }
+
+  /**
+   * Factory that get a TProtocol instance.
+   */
+  public static interface TProtocolFactory {
+
+    TProtocol get(TTransport transport);
+  }
+
+  // Factory that creates empty objects that will be initialized with values from the file.
+  private final TBaseFactory<T> baseFactory;
+
+  // TProtocol implementation.
+  private final MappedFileTBinaryProtocol protocol;
+
+  private final int maxMessageSize;
+
+  public MappedThriftReader(
+      String path,
+      TBaseFactory<T> baseFactory,
+      int maxMessageSize) throws IOException {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(path));
+    this.baseFactory = Preconditions.checkNotNull(baseFactory);
+    this.protocol = new MappedFileTBinaryProtocol(new File(path));
+
+    this.maxMessageSize = maxMessageSize;
+  }
+
+  /**
+   * Read one thrift message.
+   *
+   * @return next thrift message from the reader. null if no thrift message in the reader.
+   * @throws IOException when file error.
+   * @throws TException  when parse error.
+   */
+  public T read() throws IOException, TException {
+    // If frame buffer is empty and we are at EOF of underlying input stream, return null.
+    if (protocol.getBytesRemainingInBuffer() == 0 && protocol.isEOF()) {
+      return null;
+    }
+
+    T t = baseFactory.get();
+    t.read(protocol);
+    return t;
+  }
+
+  /**
+   * Set byte offset of the next message to be read.
+   *
+   * @param byteOffset byte offset.
+   * @throws IOException on file error.
+   */
+  public void setByteOffset(int byteOffset) throws IOException {
+    protocol.setByteOffset(byteOffset);
+  }
+
+  /**
+   * Close the reader.
+   *
+   * @throws IOException on file error.
+   */
+  public void close() throws IOException {
+    // automatically closed
+  }
+
+  public long getByteOffset() {
+    return protocol.getByteOffset();
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -308,6 +309,18 @@ public class SingerUtils {
       }
     }
     return SingerUtils.getHostname();
+  }
+  
+  /**
+   * Convert a {@link ByteBuffer} to byte array. 
+   * Reads all bytes from current position to the limit of the buffer into a byte array.
+   * @param buf
+   * @return
+   */
+  public static byte[] readFromByteBuffer(ByteBuffer buf) {
+    byte[] bytes = new byte[buf.limit()-buf.position()];
+    buf.get(bytes);
+    return bytes;
   }
   
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
@@ -26,6 +26,7 @@ import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
 import com.pinterest.singer.thrift.configuration.SingerRestartConfig;
 import com.pinterest.singer.utils.PartitionComparator;
+import com.pinterest.singer.utils.SingerUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -205,13 +206,13 @@ public class KafkaWriter implements LogStreamWriter {
       for (LogMessage msg : logMessages) {
         byte[] key = null;
         if (msg.isSetKey()) {
-          key = msg.getKey();
+          key = SingerUtils.readFromByteBuffer(msg.BufferForKey());
         }
         int partitionId = partitioner.partition(key, validPartitions);
         if (skipNoLeaderPartitions) {
           partitionId = validPartitions.get(partitionId).partition();
         }
-        keyedMessage = new ProducerRecord<>(topic, partitionId, key, msg.getMessage());
+        keyedMessage = new ProducerRecord<>(topic, partitionId, key, SingerUtils.readFromByteBuffer(msg.BufferForMessage()));
         buckets.get(partitionId).add(keyedMessage);
       }
     } catch (Exception e) {

--- a/singer/src/test/java/com/pinterest/singer/reader/thrift/TestSingerTBinaryProtocol.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/thrift/TestSingerTBinaryProtocol.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.reader.thrift;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TByteBuffer;
+import org.apache.thrift.transport.TFramedTransport;
+import org.apache.thrift.transport.TIOStreamTransport;
+import org.junit.Test;
+
+import com.pinterest.singer.client.ThriftCodec;
+import com.pinterest.singer.client.ThriftLogger;
+import com.pinterest.singer.client.ThriftLoggerConfig;
+import com.pinterest.singer.client.ThriftLoggerFactory;
+import com.pinterest.singer.reader.ByteOffsetInputStream;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.utils.SingerUtils;
+
+public class TestSingerTBinaryProtocol {
+
+  @Test
+  public void testSimpleReadWrite() throws TException {
+    LogMessage msg = new LogMessage();
+    String key = "hellow world";
+    msg.setKey(key.getBytes());
+    String value = "abcdef";
+    msg.setMessage(value.getBytes());
+    long checksum = 1233432L;
+    msg.setChecksum(checksum);
+    long nanoTime = System.nanoTime();
+    msg.setTimestampInNanos(nanoTime);
+    byte[] serialize = ThriftCodec.getInstance().serialize(msg);
+
+    TProtocol pr = new TBinaryProtocol(new TByteBuffer(ByteBuffer.wrap(serialize)));
+    LogMessage lm = new LogMessage();
+    lm.read(pr);
+    assertEquals(nanoTime, lm.getTimestampInNanos());
+    assertEquals(key, new String(lm.getKey()));
+    assertEquals(value, new String(lm.getMessage()));
+    assertEquals(checksum, lm.getChecksum());
+
+  }
+
+  @Test
+  public void testSimpleMappedReadWrite() throws Exception {
+    String key = "hellow world";
+    String value = "abcdefdfsfadsfrwqerfwerwe";
+    int COUNT = 1000;
+    for (int i = 0; i < 10; i++) {
+      value += value;
+    }
+    long nanoTime = System.nanoTime();
+    File baseDir = new File("target/tl");
+    baseDir.mkdirs();
+    for (File file : baseDir.listFiles()) {
+      file.delete();
+    }
+    String file = "test1";
+    ThriftLoggerConfig thriftLoggerConfig = new ThriftLoggerConfig(baseDir, file, 1000,
+        1024 * 1024 * 1024);
+    ThriftLoggerFactory.initialize();
+    ThriftLogger logger = ThriftLoggerFactory.getLogger(thriftLoggerConfig);
+    for (int i = 0; i < COUNT; i++) {
+      logger.append(key.getBytes(), value.getBytes(), nanoTime);
+    }
+    logger.close();
+
+    File dataFile = new File(baseDir, file);
+
+    long ts = System.nanoTime();
+    MappedFileTBinaryProtocol pr1 = new MappedFileTBinaryProtocol(dataFile);
+    for (int i = 0; i < COUNT; i++) {
+      LogMessage lm = new LogMessage();
+      lm.read(pr1);
+      assertEquals(nanoTime, lm.getTimestampInNanos());
+      assertEquals(key, new String(SingerUtils.readFromByteBuffer(lm.BufferForKey())));
+      assertEquals(value, new String(SingerUtils.readFromByteBuffer(lm.BufferForMessage())));
+    }
+    ts = System.nanoTime() - ts;
+    System.out.println("MappedThriftReader:" + ts / 1000 + "us");
+   
+    ts = System.nanoTime();
+    TProtocol pr = new TBinaryProtocol(new TFramedTransport(
+        new TIOStreamTransport(
+            new ByteOffsetInputStream(new RandomAccessFile(dataFile, "r"), 1024 * 1024)),
+        value.length() + 512));
+
+    for (int i = 0; i < COUNT; i++) {
+      LogMessage lm = new LogMessage();
+      lm.read(pr);
+      assertEquals(nanoTime, lm.getTimestampInNanos());
+      assertEquals(key, new String(lm.getKey()));
+      assertEquals(value, new String(lm.getMessage()));
+    }
+    ts = System.nanoTime() - ts;
+    System.out.println("ThriftReader:" + ts / 1000 + "us");
+    
+    
+
+  }
+
+//  @Test
+  public void testMappedContinuousReads() throws Exception {
+    String key = "hellow world";
+    String value = "abcdefdfsfadsfrwqerfwerwe";
+    int COUNT = 5000;
+    for (int i = 0; i < 10; i++) {
+      value += value;
+    }
+    long nanoTime = System.nanoTime();
+    File baseDir = new File("target/tl");
+    baseDir.mkdirs();
+    for (File file : baseDir.listFiles()) {
+      file.delete();
+    }
+    String file = "test1";
+    ThriftLoggerConfig thriftLoggerConfig = new ThriftLoggerConfig(baseDir, file, 1000,
+        1024 * 1024 * 500);
+    ThriftLoggerFactory.initialize();
+    ThriftLogger logger = ThriftLoggerFactory.getLogger(thriftLoggerConfig);
+    for (int i = 0; i < COUNT; i++) {
+      logger.append(key.getBytes(), value.getBytes(), nanoTime);
+    }
+    logger.close();
+
+    File dataFile = new File(baseDir, file);
+    TProtocol pr = new TBinaryProtocol(new TFramedTransport(
+        new TIOStreamTransport(
+            new ByteOffsetInputStream(new RandomAccessFile(dataFile, "r"), 1024 * 1024)),
+        value.length() + 512));
+
+    for (int i = 0; i < COUNT; i++) {
+      LogMessage lm = new LogMessage();
+      lm.read(pr);
+      assertEquals(nanoTime, lm.getTimestampInNanos());
+      assertEquals(key, new String(lm.getKey()));
+      assertEquals(value, new String(lm.getMessage()));
+    }
+
+    TProtocol pr1 = new MappedFileTBinaryProtocol(dataFile);
+    for (int i = 0; i < COUNT; i++) {
+      LogMessage lm = new LogMessage();
+      lm.read(pr1);
+      assertEquals(nanoTime, lm.getTimestampInNanos());
+      assertEquals(key, new String(SingerUtils.readFromByteBuffer(lm.BufferForKey())));
+      assertEquals(value, new String(SingerUtils.readFromByteBuffer(lm.BufferForMessage())));
+    }
+  }
+
+}


### PR DESCRIPTION
Mapped Thrift Reader uses memory mapped files instead of RandomAccessFile to read thrift logs. The advantage of this design is the reduced buffer copy and object overhead for Singer thereby reducing net heap usage. Since the data is kept in page cache in both implementations this implementation doesn't increase any overheads.