### PR TITLE
Enable Singer to attach LoggingAuditHeaders

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -105,4 +105,7 @@ public class SingerMetrics {
   public static final String AUDIT_HEADERS_METADATA_COUNT_MISMATCH = "singer.audit.headers_metadata_count_mismatch";
   public static final String AUDIT_HEADERS_METADATA_COUNT_MATCH = "singer.audit.headers_metadata_count_match";
 
+  // Used when logging audit is enabled and is started at Singer instead of ThriftLogger.
+  public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE = "singer.audit.log_message_headers_set";
+  public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE_EXCEPTION = "singer.audit.log_message_headers_set.exception";
 }


### PR DESCRIPTION
Enable Singer to attach LoggingAuditHeaders if logging audit starts at Singer.

It is used for log files not generated by ThriftLogger.