### PR TITLE
add timestamp field to logging audit headers

### DIFF
--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/AuditHeadersGenerator.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/AuditHeadersGenerator.java
@@ -71,7 +71,8 @@ public class AuditHeadersGenerator {
         .setLogName(this.logName)
         .setPid(this.pid)
         .setSession(this.session)
-        .setLogSeqNumInSession(this.logSeqNumInSession);
+        .setLogSeqNumInSession(this.logSeqNumInSession)
+        .setTimestamp(System.currentTimeMillis());
   }
 
 }

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditEventGenerator.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditEventGenerator.java
@@ -46,6 +46,7 @@ public class LoggingAuditEventGenerator {
         .setStartAtCurrentStage(auditConfigs.get(loggingAuditName).isStartAtCurrentStage())
         .setStopAtCurrentStage(auditConfigs.get(loggingAuditName).isStopAtCurrentStage())
         .setLoggingAuditHeaders(headers)
+        .setHeaderGeneratedTimestamp(headers.getTimestamp())
         .setMessageValid(messageValid)
         .setMessageAcknowledgedTimestamp(messageAcknowledgedTimestamp)
         .setKafkaCluster(kafkaCluster)

--- a/singer-commons/src/main/thrift/loggingaudit.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit.thrift
@@ -52,6 +52,11 @@ struct LoggingAuditHeaders {
     *  Log sequence number for a given session and it starts with 0.
     */
    5: required i32 logSeqNumInSession;
+
+   /**
+    *  Timstamp (millisecond) when the audit header is generated.
+    */
+   6: required i64 timestamp;
 }
 
 
@@ -117,7 +122,7 @@ struct LoggingAuditEvent {
     *  (1) auditing is ended at current stage (indicated by field 4 of LoggingAuditEvent struct)
     *  (2) acknowledge timestamp cannot be obtained due to configuration or error.
     */
-   7: optional i64  messageAcknowledgedTimestamp = -1;
+    7: optional i64  messageAcknowledgedTimestamp = -1;
 
 
    /**
@@ -141,6 +146,12 @@ struct LoggingAuditEvent {
     *  value "".
     */
     10: optional string topic = "";
+
+   /**
+    *  used to bucket audit events into different time window
+    */
+    11: required i64 headerGeneratedTimestamp;
+
 
 }
 


### PR DESCRIPTION
add timestamp field to logging audit headers. This timestamp is used to bucket audit events (containing logging audit headers) into time window.  timestamp generation and setting are handled by the audit client library under the hood. There is not API change. 