### PR TITLE
Adding producer metric monitoring framework

### DIFF
--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -180,6 +180,12 @@
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>1.11.35</version>
         </dependency>
+        <dependency>
+		    <groupId>com.salesforce.kafka.test</groupId>
+		    <artifactId>kafka-junit4</artifactId>
+		    <version>3.2.0</version>
+		    <scope>test</scope>
+		</dependency>
     </dependencies>
     <build>
         <resources>

--- a/singer/src/main/java/com/pinterest/singer/SingerMain.java
+++ b/singer/src/main/java/com/pinterest/singer/SingerMain.java
@@ -54,6 +54,14 @@ public final class SingerMain {
       } catch (Throwable t) {
         LOG.error("Shutdown failure: log monitor : ", t);
       }
+      
+      try {
+        if (SingerSettings.getKafkaProducerMonitorThread() != null) {
+          SingerSettings.getKafkaProducerMonitorThread().interrupt();
+        }
+      }catch(Throwable t) {
+        LOG.error("Shutdown error: kafka producer metrics monitor : ", t);
+      }
 
       try {
         if (SingerSettings.heartbeatGenerator != null) {
@@ -68,7 +76,7 @@ public final class SingerMain {
       } catch (Throwable t) {
         LOG.error("Shutdown failure: kafka producers : ", t);
       }
-
+      
       try {
         OpenTsdbMetricConverter.incr("singer.shutdown", 1);
         if (statsPusher!= null) {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
@@ -25,6 +25,7 @@ import com.pinterest.singer.monitor.FileSystemMonitor;
 import com.pinterest.singer.monitor.LogStreamManager;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+import com.pinterest.singer.writer.KafkaProducerMetricsMonitor;
 import com.twitter.ostrich.stats.Stats;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -92,6 +93,8 @@ public final class SingerSettings {
   
   //environment is production by default
   private static Environment environment = new Environment();
+  
+  private static Thread kafkaProducerMonitorThread;
 
   private SingerSettings() {
   }
@@ -148,6 +151,10 @@ public final class SingerSettings {
           logWritingExecutors.put(clusterSig, threadPool);
         }
       }
+      
+      kafkaProducerMonitorThread = new Thread(new KafkaProducerMetricsMonitor());
+      kafkaProducerMonitorThread.setDaemon(true);
+      kafkaProducerMonitorThread.start();
     }
 
     if (singerConfig != null
@@ -318,5 +325,9 @@ public final class SingerSettings {
   @VisibleForTesting
   public static void setEnvironment(Environment environment) {
     SingerSettings.environment = environment;
+  }
+  
+  public static Thread getKafkaProducerMonitorThread() {
+    return kafkaProducerMonitorThread;
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaProducerManager.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaProducerManager.java
@@ -24,6 +24,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -124,5 +125,13 @@ public class KafkaProducerManager {
         LOG.error("Shutdown failure : ", e);
       }
     }
+  }
+  
+  /**
+   * Returns map of all {@link KafkaProducer}s in the pool
+   * @return map of producers
+   */
+  public Map<KafkaProducerConfig, KafkaProducer<byte[], byte[]>> getProducers() {
+    return producers;
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaProducerMetricsMonitor.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaProducerMetricsMonitor.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
+
+/**
+ * Responsible for pulling metrics from {@link KafkaProducer} and copying them
+ * to Ostrich so they can be accessed and forwarded. This helps provide
+ * additional instrumentation on Singer and how it's performing.
+ */
+public class KafkaProducerMetricsMonitor implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaProducerMetricsMonitor.class);
+  public static final Set<String> PRODUCER_METRICS_WHITELIST = new HashSet<>(
+      Arrays.asList("buffer-total-bytes", "buffer-available-bytes"));
+  // sample every 60seconds
+  private static final int SAMPLING_INTERVAL = 60_000;
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        publishKafkaProducerMetricsToOstrich();
+      } catch (Exception e) {
+        LOG.warn("Error publishing KafkaProducer metrics", e);
+      }
+      try {
+        Thread.sleep(SAMPLING_INTERVAL);
+      } catch (InterruptedException e) {
+        LOG.warn("KafkaProducerMetricsMonitor thread interrupted, exiting");
+        break;
+      }
+    }
+  }
+
+  @SuppressWarnings({ "deprecation" })
+  protected void publishKafkaProducerMetricsToOstrich() {
+    Map<KafkaProducerConfig, KafkaProducer<byte[], byte[]>> producers = KafkaProducerManager
+        .getInstance().getProducers();
+    for (Entry<KafkaProducerConfig, KafkaProducer<byte[], byte[]>> kafkaProducerEntry : producers
+        .entrySet()) {
+      KafkaProducerConfig key = kafkaProducerEntry.getKey();
+      String signature = convertSignatureToTag(key);
+      Map<MetricName, ? extends Metric> metrics = kafkaProducerEntry.getValue().metrics();
+      for (Entry<MetricName, ? extends Metric> entry : metrics.entrySet()) {
+        if (PRODUCER_METRICS_WHITELIST.contains(entry.getKey().name())) {
+          OpenTsdbMetricConverter.gauge(entry.getKey().name(), entry.getValue().value(),
+              "cluster=" + signature);
+        }
+      }
+    }
+  }
+
+  public static String convertSignatureToTag(KafkaProducerConfig key) {
+    return key.getKafkaClusterSignature().replace("/discovery/", "").replace("/prod", "")
+        .replace("/", "_");
+  }
+
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/TestKafkaProducerMetricsMonitor.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/TestKafkaProducerMetricsMonitor.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.Test;
+
+import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
+import com.twitter.ostrich.stats.Stats;
+
+public class TestKafkaProducerMetricsMonitor {
+
+  @Test
+  public void testSignatureTagExtraction() {
+    KafkaProducerConfig config = new KafkaProducerConfig("/discovery/testkafka/prod",
+        Arrays.asList(), "-1");
+    assertEquals("testkafka", KafkaProducerMetricsMonitor.convertSignatureToTag(config));
+  }
+
+  @Test
+  public void testPublishMetrics() {
+    KafkaProducerConfig config = new KafkaProducerConfig("/discovery/testkafka/prod",
+        Arrays.asList("localhost:9092"), "-1");
+    KafkaProducerManager.getInstance().getProducers().clear();
+    KafkaProducer<byte[], byte[]> producer = KafkaProducerManager.getProducer(config);
+    KafkaProducerMetricsMonitor monitor = new KafkaProducerMetricsMonitor();
+    monitor.publishKafkaProducerMetricsToOstrich();
+    producer.close();
+    for (String metricName : KafkaProducerMetricsMonitor.PRODUCER_METRICS_WHITELIST) {
+      Object gauge = Stats.getGauge(metricName+" cluster=testkafka").get();
+      assertNotNull(gauge);
+    }
+  }
+
+}


### PR DESCRIPTION
This allows us to monitor specific kafka producer metrics. This will help monitor performance, resource consumption and improve tuning.