### PR TITLE
Shadow Singer to allow validation / testing of Singer

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -299,11 +299,6 @@ struct SingerConfig {
    */ 
   15: optional KubeConfig kubeConfig;
   
-  /**
-   * Active or deactivate command server
-   */
-  16: optional bool runCommandServer = false;
-  
   /** 
    * Class name for stats pusher
    */
@@ -317,5 +312,15 @@ struct SingerConfig {
   19: optional bool loggingAuditEnabled = false;
 
   20: optional loggingaudit_config.LoggingAuditClientConfig loggingAuditClientConfig;
-
+  
+  /**
+   * Run singer in shadow mode
+   */
+  21: optional bool shadowModeEnabled = false;
+  
+  /**
+   * Run singer in shadow mode
+   */
+  22: optional string shadowModeServersetMappingFile;
+  
 }

--- a/singer/src/main/java/com/pinterest/singer/SingerMain.java
+++ b/singer/src/main/java/com/pinterest/singer/SingerMain.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 public final class SingerMain {
 
   private static final String SINGER_METRICS_PREFIX = "singer";
+  private static final String SHADOW_METRICS_PREFIX = SINGER_METRICS_PREFIX + ".shadow";
   private static final Logger LOG = LoggerFactory.getLogger(SingerMain.class);
   private static final int STATS_PUSH_INTERVAL_IN_MILLISECONDS = 10 * 1000;
   protected static final String hostName = SingerUtils.getHostname();
@@ -114,7 +115,7 @@ public final class SingerMain {
         HostAndPort pushHostPort = HostAndPort.fromString(singerConfig.getStatsPusherHostPort());
         // allows hostname to be overridden based on environment
         statsPusher.configure(SingerSettings.getEnvironment().getHostname()
-            , SINGER_METRICS_PREFIX
+            , singerConfig.isShadowModeEnabled()? SHADOW_METRICS_PREFIX : SINGER_METRICS_PREFIX
             , pushHostPort.getHost()
             , pushHostPort.getPort()
             , STATS_PUSH_INTERVAL_IN_MILLISECONDS);

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -53,7 +53,6 @@ public class SingerConfigDef {
   public static final String BOOTSTRAP_SERVERS_FILE = "bootstrap.servers.file";
   @Deprecated
   public static final String BROKER_SERVERSET = "broker.serverset";
-  @Deprecated
   public static final String BROKER_SERVERSET_DEPRECATED = "metadata.broker.serverset";
   public static final String ACKS = "acks";
 

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -109,4 +109,5 @@ public class SingerMetrics {
   // Used when logging audit is enabled and is started at Singer instead of ThriftLogger.
   public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE = "singer.audit.log_message_headers_set";
   public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE_EXCEPTION = "singer.audit.log_message_headers_set.exception";
+  public static final String SHADOW_MODE_ENABLED = "singer.shadow_mode_enabled";
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
@@ -112,6 +112,12 @@ public final class SingerSettings {
              NoSuchMethodException,
       SingerLogException {
     setSingerConfig(config);
+    
+    // mark metric if Singer is running in shadowMode
+    if (config.isShadowModeEnabled()) {
+      Stats.setGauge(SingerMetrics.SHADOW_MODE_ENABLED, 1);
+      LOG.warn("################Singer is running in shadow mode################");
+    }
 
     loadAndSetSingerEnvironmentIfConfigured(config);
     LOG.warn("Singer environment has been configured to:" + environment);

--- a/singer/src/main/java/com/pinterest/singer/environment/Environment.java
+++ b/singer/src/main/java/com/pinterest/singer/environment/Environment.java
@@ -76,4 +76,13 @@ public class Environment {
     this.hostname = hostname;
   }
 
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "Environment [locality=" + locality + ", deploymentStage=" + deploymentStage
+        + ", hostname=" + hostname + "]";
+  }
+
 }

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -30,6 +30,7 @@ import com.pinterest.singer.thrift.LogFileAndPath;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.LogMessageAndPosition;
 import com.pinterest.singer.thrift.LogPosition;
+import com.pinterest.singer.utils.LogConfigUtils;
 import com.pinterest.singer.utils.WatermarkUtils;
 
 import com.google.common.base.Preconditions;
@@ -409,6 +410,9 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
     // Get the globally unique watermark file name
     String watermarkFilename = "." + logStream.getSingerLog().getLogName()
         + "." + logStream.getLogStreamName();
+    if (LogConfigUtils.SHADOW_MODE_ENABLED) {
+      watermarkFilename = ".shadow" + watermarkFilename;
+    }
     return FilenameUtils.concat(path, watermarkFilename);
   }
 

--- a/singer/src/test/java/com/pinterest/singer/config/DirectorySingerConfiguratorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/config/DirectorySingerConfiguratorTest.java
@@ -43,7 +43,7 @@ public class DirectorySingerConfiguratorTest extends SingerTestBase {
 
   @Test
   public void testConfiguratorLoadConfigsAndReceiveLiveChanges() throws Exception {
-	dumpServerSetFiles();
+    dumpServerSetFiles();
     // Make the singer config property file
     File singerConfigFile = createSingerConfigFile(makeDirectorySingerConfigProperties());
     // Make two log config properties files in the logConfigDir.


### PR DESCRIPTION
Shadow Singer to allow validation / testing of Singer allows us to perform apples to apples comparison of two singer releases in real environment without impacting existing data flows.