### PR TITLE
Add new MemoryEfficientLogStreamProcessor to reduce memory utilization

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -18,6 +18,8 @@ struct LogStreamProcessorConfig {
   3: required i32 batchSize;
   // The maximum time in seconds for one processing cycle
   4: optional i64 processingTimeSliceInMilliseconds = 864000000;
+  // Enable memory efficient processor
+  5: optional bool enableMemoryEfficientProcessor = false;
 }
 
 enum ReaderType {

--- a/singer/src/main/java/com/pinterest/singer/common/LogStreamWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/common/LogStreamWriter.java
@@ -43,4 +43,41 @@ public interface LogStreamWriter extends Closeable {
    * @throws LogStreamWriterException when writer fails to write the LogMessages.
    */
   void writeLogMessages(List<LogMessage> messages) throws LogStreamWriterException;
+
+  /**
+   * @return if this writer implementation is committable
+   */
+  default boolean isCommittableWriter() {
+    return false;
+  }
+  
+  /**
+   * Start a new commit and run any pre-commit steps
+   * @throws LogStreamWriterException
+   */
+  default void startCommit() throws LogStreamWriterException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Send 1 LogMessage to the writer, note that writer is expected to not finalize
+   * the messages until the commit method is invoked
+   * 
+   * @param message
+   * @throws LogStreamWriterException
+   */
+  default void writeLogMessageToCommit(LogMessage message) throws LogStreamWriterException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Commit all logmessages written using {@link LogStreamWriter#writeCommittableLogMessage}
+   * 
+   * NOTE: by default this method throws UnsupportedOperationException
+   * @param numLogMessagesRead 
+   * @throws LogStreamWriterException
+   */
+  default void endCommit(int numLogMessagesRead) throws LogStreamWriterException {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -41,6 +41,8 @@ public class SingerConfigDef {
 
   public static final String PROCESS_TIME_SLICE_MILLIS = "processingTimeSliceInMilliseconds";
   public static final String PROCESS_TIME_SLICE_SECS = "processingTimeSliceInSeconds";
+  public static final String PROCESS_ENABLE_MEMORY_EFFICIENCY = "enableMemoryEfficiency";
+  
   public static final String PRODUCER_CONFIG_PREFIX = "producerConfig.";
   public static final String SKIP_NO_LEADER_PARTITIONS = "skipNoLeaderPartitions";
   public static final String TOPIC = "topic";

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -69,16 +69,16 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
   private final String logDecider;
 
   // LogStream to be processed.
-  private final LogStream logStream;
+  protected final LogStream logStream;
 
   // Reader for the LogStream.
-  private final LogStreamReader reader;
+  protected final LogStreamReader reader;
 
   // Writer for the LogStream.
-  private final LogStreamWriter writer;
+  protected final LogStreamWriter writer;
 
   // Processor batch size.
-  private int batchSize;
+  protected int batchSize;
   private final int batchSizeOriginal;
 
   // Randomizer for initial processing delay.
@@ -118,10 +118,10 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
   private ScheduledFuture<?> scheduledFuture;
 
   // Committed LogPosition so far in the LogStream.
-  private LogPosition committedPosition;
+  protected LogPosition committedPosition;
 
   // Counter of LogMessages that have been committed since this processor starts.
-  private long numOfLogMessagesCommitted;
+  protected long numOfLogMessagesCommitted;
 
   // The last modification time of the stream which we have already successfully processed up to. -1
   // if no processing happened.
@@ -474,7 +474,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
    * @return number of LogMessage processed.
    * @throws Exception when failed to process the message batch.
    */
-  private int processLogMessageBatch() throws IOException, LogStreamWriterException, TException {
+  protected int processLogMessageBatch() throws IOException, LogStreamWriterException, TException {
     LOG.debug("Start processing a batch of log messages in log stream: {} starting at position: {}",
         logStream, committedPosition);
     LogPosition batchStartPosition = committedPosition;
@@ -565,7 +565,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
    * @param persistent Whether the position should be saved to watermark file.
    * @throws Exception when fail to commit the LogPosition.
    */
-  private void commitLogPosition(LogPosition position, boolean persistent)
+  protected void commitLogPosition(LogPosition position, boolean persistent)
       throws IOException, TException {
     this.committedPosition = position;
     if (persistent) {

--- a/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.processor;
+
+import java.io.IOException;
+
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.LogStreamReader;
+import com.pinterest.singer.common.LogStreamWriter;
+import com.pinterest.singer.common.errors.LogStreamWriterException;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
+import com.pinterest.singer.thrift.LogPosition;
+
+/**
+ * Memory optimized processor that processes 1 LogMessage at a time instead of
+ * buffering an entire batch in a list. This enable much smaller memory
+ * footprint since only 1 message needs to be actively buffered.
+ * 
+ * This processor should be preferred for use if memory usage is of concern
+ * and/or size of batch is large enough to not fit in heap.
+ *
+ */
+public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(MemoryEfficientLogStreamProcessor.class);
+
+  public MemoryEfficientLogStreamProcessor(LogStream logStream,
+                                           String logDecider,
+                                           LogStreamReader reader,
+                                           LogStreamWriter writer,
+                                           int batchSize,
+                                           long processingIntervalInMillisMin,
+                                           long processingIntervalInMillisMax,
+                                           long processingTimeSliceInMilliseconds,
+                                           int logRetentionInSecs) {
+    super(logStream, logDecider, reader, writer, batchSize, processingIntervalInMillisMin,
+        processingIntervalInMillisMax, processingTimeSliceInMilliseconds, logRetentionInSecs);
+  }
+
+  @Override
+  protected int processLogMessageBatch() throws IOException, LogStreamWriterException, TException {
+    LOG.debug("Start processing a batch of log messages in log stream: {} starting at position: {}",
+        logStream, committedPosition);
+    LogPosition batchStartPosition = committedPosition;
+
+    int logMessagesRead = 0;
+    // Read a batch of LogMessages.
+    LogMessageAndPosition message = null;
+    for (int i = 0; i < this.batchSize; ++i) {
+      try {
+        // use a tmp variable to preserve valid last read message
+        LogMessageAndPosition tmp = reader.readLogMessageAndPosition();
+        if (tmp == null) {
+          // We run out of LogMessage, we are done with this processing cycle.
+          break;
+        } else {
+          message = tmp;
+          logMessagesRead++;
+        }
+      } catch (Exception e) {
+        String errorString = "Caught exception when reading the current batch of messages from "
+            + logStream;
+        if (logMessagesRead > 0) {
+          errorString += "The last good log position is: " + message.getNextPosition()
+              + ". Abort this processing cycle after sending the log messages we get so far.";
+        } else {
+          errorString += "Abort this processing cycle without reading any messages.";
+        }
+        LOG.error(errorString, e);
+        // break out of the loop as we have encountered an error
+        break;
+      }
+      // keeping writes out of try catch so as to not loose data due to write
+      // errors by incorrectly skipping the checkpoint (committed position)
+      // this situation can happen if there is partial write success
+      if (i == 0) {
+        // because there is some data to read we need to prepare the commit
+        writer.startCommit();
+      }
+      writer.writeLogMessageToCommit(message.getLogMessage());
+    }
+
+    if (logMessagesRead > 0) {
+      // Write the batch of LogMessages.
+      writer.endCommit(logMessagesRead);
+
+      LogMessage lastMessage = message.getLogMessage();
+      if (lastMessage.isSetTimestampInNanos()) {
+        logStream.setLatestProcessedMessageTime(lastMessage.getTimestampInNanos() / 1000000);
+      }
+      // The new committed position is the position after the last written LogMessage.
+      LogPosition newCommittedPosition = message.getNextPosition();
+
+      commitLogPosition(newCommittedPosition, true);
+      numOfLogMessagesCommitted += logMessagesRead;
+      LOG.debug("Done processing {} log messages in LogStream {} from position {} to position {}.",
+          logMessagesRead, this.logStream, batchStartPosition, committedPosition);
+    } else {
+      LOG.debug("Done processing log messages in LogStream {} : no new messages.", this.logStream);
+    }
+    return logMessagesRead;
+  }
+
+}

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -952,6 +952,10 @@ public class LogConfigUtils {
 
     LogStreamProcessorConfig config;
     config = new LogStreamProcessorConfig(minIntervalInMillis, maxIntervalInMillis, batchSize);
+    if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_ENABLE_MEMORY_EFFICIENCY)) {
+      config.setEnableMemoryEfficientProcessor(
+          processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_MEMORY_EFFICIENCY));
+    }
     config.setProcessingTimeSliceInMilliseconds(processingTimeSliceInMilliseconds);
     return config;
   }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
@@ -64,45 +64,45 @@ public class KafkaWriter implements LogStreamWriter {
 
   public static final String HOSTNAME = SingerSettings.getEnvironment().getHostname();
   private static final Logger LOG = LoggerFactory.getLogger(KafkaWriter.class);
-  private static final PartitionComparator COMPARATOR = new PartitionComparator();
+  protected static final PartitionComparator COMPARATOR = new PartitionComparator();
 
   // Counter for the number of batch message writing failures
-  private static AtomicInteger failureCounter = new AtomicInteger(0);
+  protected static AtomicInteger failureCounter = new AtomicInteger(0);
 
-  private final LogStream logStream;
+  protected final LogStream logStream;
 
   // Topic to which this LogWriter writes.
-  private final String topic;
+  protected final String topic;
 
-  private final String logName;
+  protected final String logName;
 
-  private final boolean skipNoLeaderPartitions;
+  protected final boolean skipNoLeaderPartitions;
 
-  private final boolean auditingEnabled;
+  protected final boolean auditingEnabled;
 
-  private final KafkaProducerConfig producerConfig;
+  protected final KafkaProducerConfig producerConfig;
 
-  private final String kafkaClusterSig;
+  protected final String kafkaClusterSig;
 
-  private final ExecutorService clusterThreadPool;
+  protected final ExecutorService clusterThreadPool;
 
-  private final int writeTimeoutInSeconds;
+  protected final int writeTimeoutInSeconds;
 
-  private KafkaMessagePartitioner partitioner;
+  protected KafkaMessagePartitioner partitioner;
 
-  public boolean enableHeadersInjector = false;
+  protected boolean enableHeadersInjector = false;
 
-  private boolean enableLoggingAudit = false;
+  protected boolean enableLoggingAudit = false;
 
-  private AuditHeadersGenerator auditHeadersGenerator = null;
+  protected AuditHeadersGenerator auditHeadersGenerator = null;
 
-  private AuditConfig auditConfig = null;
+  protected AuditConfig auditConfig = null;
 
   /**
    *  HeadersInjector will be set if enableHeadersInjector is set to true.
    *  Default is
   */
-  private HeadersInjector headersInjector = null;
+  protected HeadersInjector headersInjector = null;
 
 
   public boolean isEnableLoggingAudit() {
@@ -471,7 +471,7 @@ public class KafkaWriter implements LogStreamWriter {
     }
   }
 
-  private boolean isLoggingAuditEnabledAndConfigured(){
+  protected boolean isLoggingAuditEnabledAndConfigured(){
     return this.enableLoggingAudit && SingerSettings.getLoggingAuditClient() != null;
   }
 

--- a/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
@@ -1,0 +1,378 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.kafka;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.header.Headers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.LogStreamWriter;
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.common.errors.LogStreamWriterException;
+import com.pinterest.singer.loggingaudit.thrift.LoggingAuditHeaders;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
+import com.pinterest.singer.thrift.configuration.SingerRestartConfig;
+import com.pinterest.singer.writer.KafkaMessagePartitioner;
+import com.pinterest.singer.writer.KafkaProducerManager;
+import com.pinterest.singer.writer.KafkaWriter;
+import com.pinterest.singer.writer.KafkaWritingTaskResult;
+
+/**
+ * Committable writer that implements the commit design pattern methods of {@link LogStreamWriter}
+ * 
+ * This class allows usage of MemoryEfficientLogStreamProcessor.
+ */
+public class CommittableKafkaWriter extends KafkaWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CommittableKafkaWriter.class);
+  private List<PartitionInfo> committableValidPartitions;
+  private Map<Integer, Map<Integer, LoggingAuditHeaders>> commitableMapOfHeadersMap;
+  private Map<Integer, KafkaWritingTaskFuture> commitableBuckets;
+  private KafkaProducer<byte[], byte[]> committableProducer;
+
+  protected CommittableKafkaWriter(KafkaProducerConfig producerConfig,
+                                   KafkaMessagePartitioner partitioner,
+                                   String topic,
+                                   boolean skipNoLeaderPartitions,
+                                   ExecutorService clusterThreadPool) {
+    super(producerConfig, partitioner, topic, skipNoLeaderPartitions, clusterThreadPool);
+  }
+
+  public CommittableKafkaWriter(LogStream logStream,
+                                KafkaProducerConfig producerConfig,
+                                KafkaMessagePartitioner partitioner,
+                                String topic,
+                                boolean skipNoLeaderPartitions,
+                                ExecutorService clusterThreadPool,
+                                boolean enableHeadersInjector) {
+    super(logStream, producerConfig, partitioner, topic, skipNoLeaderPartitions, clusterThreadPool,
+        enableHeadersInjector);
+  }
+
+  public CommittableKafkaWriter(LogStream logStream,
+                                KafkaProducerConfig producerConfig,
+                                String topic,
+                                boolean skipNoLeaderPartitions,
+                                boolean auditingEnabled,
+                                String auditTopic,
+                                String partitionerClassName,
+                                int writeTimeoutInSeconds,
+                                boolean enableHeadersInjector) throws Exception {
+    super(logStream, producerConfig, topic, skipNoLeaderPartitions, auditingEnabled, auditTopic,
+        partitionerClassName, writeTimeoutInSeconds, enableHeadersInjector);
+    LOG.info("Enabled committablewriter for:" + topic);
+  }
+
+  public CommittableKafkaWriter(LogStream logStream,
+                                KafkaProducerConfig producerConfig,
+                                String topic,
+                                boolean skipNoLeaderPartitions,
+                                boolean auditingEnabled,
+                                String auditTopic,
+                                String partitionerClassName,
+                                int writeTimeoutInSeconds) throws Exception {
+    super(logStream, producerConfig, topic, skipNoLeaderPartitions, auditingEnabled, auditTopic,
+        partitionerClassName, writeTimeoutInSeconds);
+  }
+
+  @Override
+  public void startCommit() throws LogStreamWriterException {
+    committableProducer = KafkaProducerManager.getProducer(producerConfig);
+    Preconditions.checkNotNull(committableProducer);
+    if (producerConfig.isTransactionEnabled()) {
+      committableProducer.beginTransaction();
+    }
+    List<PartitionInfo> partitions = committableProducer.partitionsFor(topic);
+    List<PartitionInfo> committableSortedPartitions = new ArrayList<>(partitions);
+    Collections.sort(committableSortedPartitions, COMPARATOR);
+
+    committableValidPartitions = partitions;
+    if (skipNoLeaderPartitions) {
+      committableValidPartitions = new ArrayList<>();
+      for (PartitionInfo partitionInfo : partitions) {
+        // If there is no leader, the id value is -1
+        // github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/PartitionInfo.java
+        if (partitionInfo.leader().id() >= 0) {
+          committableValidPartitions.add(partitionInfo);
+        }
+      }
+    }
+
+    commitableBuckets = new HashMap<>();
+    commitableMapOfHeadersMap = new HashMap<>();
+
+    for (int i = 0; i < committableValidPartitions.size(); i++) {
+      // for each partitionId, there is a corresponding bucket in buckets and a
+      // corresponding headersMap in mapOfHeadersMaps.
+      PartitionInfo partitionInfo = committableValidPartitions.get(i);
+      int partitionId = partitionInfo.partition();
+      commitableBuckets.put(partitionId, new KafkaWritingTaskFuture(partitionInfo));
+      commitableMapOfHeadersMap.put(partitionId, new HashMap<Integer, LoggingAuditHeaders>());
+    }
+  }
+
+  @Override
+  public void writeLogMessageToCommit(LogMessage msg) throws LogStreamWriterException {
+    ProducerRecord<byte[], byte[]> keyedMessage;
+    byte[] key = null;
+    if (msg.isSetKey()) {
+      key = msg.getKey();
+    }
+    int partitionId = partitioner.partition(key, committableValidPartitions);
+    if (skipNoLeaderPartitions) {
+      partitionId = committableValidPartitions.get(partitionId).partition();
+    }
+    keyedMessage = new ProducerRecord<>(topic, partitionId, key, msg.getMessage());
+    Headers headers = keyedMessage.headers();
+    checkAndSetLoggingAuditHeadersForLogMessage(msg);
+    KafkaWritingTaskFuture kafkaWritingTaskFutureResult = commitableBuckets.get(partitionId);
+    List<Future<RecordMetadata>> recordMetadataList = kafkaWritingTaskFutureResult
+        .getRecordMetadataList();
+    if (msg.getLoggingAuditHeaders() != null) {
+      if (this.headersInjector != null) {
+        this.headersInjector.addHeaders(headers, msg);
+        OpenTsdbMetricConverter.incr(SingerMetrics.AUDIT_HEADERS_INJECTED, "topic=" + topic,
+            "host=" + HOSTNAME, "logName=" + msg.getLoggingAuditHeaders().getLogName(),
+            "logStreamName=" + logName);
+      }
+      // it is the index of the audited message within its bucket.
+      // note that not necessarily all messages within a bucket are being audited,
+      // thus which
+      // message within the bucket being audited should be keep track of for later
+      // sending
+      // corresponding LoggingAuditEvents.
+      int indexWithinTheBucket = recordMetadataList.size();
+      commitableMapOfHeadersMap.get(partitionId).put(indexWithinTheBucket,
+          msg.getLoggingAuditHeaders());
+    }
+
+    if (recordMetadataList.isEmpty()) {
+      kafkaWritingTaskFutureResult.setFirstProduceTimestamp(System.currentTimeMillis());
+    }
+
+    Future<RecordMetadata> send = committableProducer.send(keyedMessage);
+    recordMetadataList.add(send);
+  }
+
+  @Override
+  public void endCommit(int numLogMessages) throws LogStreamWriterException {
+    committableProducer.flush();
+    List<Future<KafkaWritingTaskResult>> resultFutures = new ArrayList<>();
+    for (Entry<Integer, KafkaWritingTaskFuture> entry : commitableBuckets.entrySet()) {
+      Future<KafkaWritingTaskResult> future = clusterThreadPool.submit(new KafkaWriteTask(entry));
+      resultFutures.add(future);
+    }
+
+    int bytesWritten = 0;
+    int maxKafkaBatchWriteLatency = 0;
+    boolean anyBucketSendFailed = false;
+    try {
+      for (Future<KafkaWritingTaskResult> f : resultFutures) {
+        KafkaWritingTaskResult result = f.get();
+        if (!result.success) {
+          LOG.error("Failed to write messages to kafka topic {}", topic, result.exception);
+          anyBucketSendFailed = true;
+        } else {
+          bytesWritten += result.getWrittenBytesSize();
+          // get the max write latency
+          maxKafkaBatchWriteLatency = Math.max(maxKafkaBatchWriteLatency,
+              result.getKafkaBatchWriteLatencyInMillis());
+          if (isLoggingAuditEnabledAndConfigured()) {
+            int bucketIndex = result.getPartition();
+            // when result.success is true, the number of recordMetadata SHOULD be the same
+            // as the number of ProducerRecord. The size mismatch should never happen.
+            // Adding this if-check is just an additional verification to make sure the size
+            // match and the audit events sent out is indeed corresponding to those log messages
+            // that are audited.
+            List<Future<RecordMetadata>> recordMetadataList = commitableBuckets.get(bucketIndex)
+                .getRecordMetadataList();
+            if (bucketIndex >= 0
+                && result.getRecordMetadataList().size() != recordMetadataList.size()) {
+              // this should never happen!
+              LOG.warn(
+                  "Number of ProducerRecord does not match the number of RecordMetadata, "
+                      + "LogName:{}, Topic:{}, BucketIndex:{}, result_size:{}, bucket_size:{}",
+                  logName, topic, bucketIndex, result.getRecordMetadataList().size(),
+                  recordMetadataList.size());
+              OpenTsdbMetricConverter.incr(SingerMetrics.AUDIT_HEADERS_METADATA_COUNT_MISMATCH, 1,
+                  "topic=" + topic, "host=" + HOSTNAME, "logStreamName=" + logName,
+                  "partition=" + bucketIndex);
+            } else {
+              // regular code execution path
+              enqueueLoggingAuditEvents(result, commitableMapOfHeadersMap.get(bucketIndex));
+              OpenTsdbMetricConverter.incr(SingerMetrics.AUDIT_HEADERS_METADATA_COUNT_MATCH, 1,
+                  "host=" + HOSTNAME, "logStreamName=" + logName);
+            }
+          }
+        }
+      }
+      if (anyBucketSendFailed) {
+        throw new LogStreamWriterException("Failed to write messages to kafka");
+      }
+
+      if (producerConfig.isTransactionEnabled()) {
+        committableProducer.commitTransaction();
+        OpenTsdbMetricConverter.incr(SingerMetrics.NUM_COMMITED_TRANSACTIONS, 1, "topic=" + topic,
+            "host=" + HOSTNAME, "logname=" + logName);
+      }
+      OpenTsdbMetricConverter.gauge(SingerMetrics.KAFKA_THROUGHPUT, bytesWritten, "topic=" + topic,
+          "host=" + HOSTNAME, "logname=" + logName);
+      OpenTsdbMetricConverter.gauge(SingerMetrics.KAFKA_LATENCY, maxKafkaBatchWriteLatency,
+          "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
+      OpenTsdbMetricConverter.incr(SingerMetrics.NUM_KAFKA_MESSAGES, numLogMessages,
+          "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
+    } catch (Exception e) {
+      LOG.error("Caught exception when write " + numLogMessages + " messages to producer.", e);
+
+      SingerRestartConfig restartConfig = SingerSettings.getSingerConfig().singerRestartConfig;
+      if (restartConfig != null && restartConfig.restartOnFailures
+          && failureCounter.incrementAndGet() > restartConfig.numOfFailuesAllowed) {
+        LOG.error("Encountered {} kafka logging failures.", failureCounter.get());
+      }
+      if (producerConfig.isTransactionEnabled()) {
+        committableProducer.abortTransaction();
+        OpenTsdbMetricConverter.incr(SingerMetrics.NUM_ABORTED_TRANSACTIONS, 1, "topic=" + topic,
+            "host=" + HOSTNAME, "logname=" + logName);
+      }
+      KafkaProducerManager.resetProducer(producerConfig);
+      OpenTsdbMetricConverter.incr("singer.writer.producer_reset", 1, "topic=" + topic,
+          "host=" + HOSTNAME);
+      OpenTsdbMetricConverter.incr("singer.writer.num_kafka_messages_delivery_failure",
+          numLogMessages, "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
+
+      throw new LogStreamWriterException("Failed to write messages to topic " + topic, e);
+    } finally {
+      for (Future<KafkaWritingTaskResult> f : resultFutures) {
+        if (!f.isDone() && !f.isCancelled()) {
+          f.cancel(true);
+        }
+      }
+    }
+  }
+
+  @Override
+  public boolean isCommittableWriter() {
+    return true;
+  }
+
+  protected final class KafkaWriteTask implements Callable<KafkaWritingTaskResult> {
+    private final Entry<Integer, KafkaWritingTaskFuture> entry;
+
+    protected KafkaWriteTask(Entry<Integer, KafkaWritingTaskFuture> entry) {
+      this.entry = entry;
+    }
+
+    @Override
+    public KafkaWritingTaskResult call() throws LogStreamWriterException {
+      KafkaWritingTaskResult result = null;
+      KafkaWritingTaskFuture task = entry.getValue();
+      int size = task.getRecordMetadataList().size();
+      PartitionInfo partitionInfo = task.getPartitionInfo();
+      int leaderNode = partitionInfo.leader().id();
+      if (size > 0) {
+        OpenTsdbMetricConverter.addMetric(SingerMetrics.WRITER_BATCH_SIZE, size, "topic=" + topic,
+            "host=" + KafkaWriter.HOSTNAME);
+      }
+      try {
+        List<RecordMetadata> recordMetadataList = new ArrayList<>();
+        int bytesWritten = 0;
+        for (Future<RecordMetadata> future : task.getRecordMetadataList()) {
+          if (future.isCancelled()) {
+            result = new KafkaWritingTaskResult(false, 0, 0);
+            break;
+          } else {
+            // We will get TimeoutException if the wait timed out
+            RecordMetadata recordMetadata = future.get(writeTimeoutInSeconds, TimeUnit.SECONDS);
+
+            // used for tracking metrics
+            if (recordMetadata != null) {
+              bytesWritten += recordMetadata.serializedKeySize()
+                  + recordMetadata.serializedValueSize();
+              recordMetadataList.add(recordMetadata);
+            }
+          }
+        }
+        if (result == null) {
+          // we can down convert since latency should be less that Integer.MAX_VALUE
+          int kafkaLatency = (int) (System.currentTimeMillis() - task.getFirstProduceTimestamp());
+          // we shouldn't have latency creater than 2B milliseoncds so it should be okay
+          // to downcast to integer
+          result = new KafkaWritingTaskResult(true, bytesWritten, (int) kafkaLatency);
+          result.setRecordMetadataList(recordMetadataList);
+          result.setPartition(partitionInfo.partition());
+          OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_SUCCESS, 1,
+              "broker=" + leaderNode);
+          OpenTsdbMetricConverter.addGranularMetric(SingerMetrics.BROKER_WRITE_LATENCY,
+              kafkaLatency, "broker=" + leaderNode);
+        }
+      } catch (org.apache.kafka.common.errors.RecordTooLargeException e) {
+        LOG.error("Kafka write failure due to excessively large message size", e);
+        OpenTsdbMetricConverter.incr(SingerMetrics.OVERSIZED_MESSAGES, 1, "topic=" + topic,
+            "host=" + KafkaWriter.HOSTNAME);
+        result = new KafkaWritingTaskResult(false, e);
+      } catch (org.apache.kafka.common.errors.SslAuthenticationException e) {
+        LOG.error("Kafka write failure due to SSL authentication failure", e);
+        OpenTsdbMetricConverter.incr(SingerMetrics.WRITER_SSL_EXCEPTION, 1, "topic=" + topic,
+            "host=" + KafkaWriter.HOSTNAME);
+        result = new KafkaWritingTaskResult(false, e);
+      } catch (Exception e) {
+        String errorMsg = "Failed to write " + size + " messages to kafka";
+        LOG.error(errorMsg, e);
+        OpenTsdbMetricConverter.incr(SingerMetrics.WRITE_FAILURE, 1, "topic=" + topic,
+            "host=" + KafkaWriter.HOSTNAME);
+        OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_FAILURE, 1,
+            "broker=" + leaderNode);
+        result = new KafkaWritingTaskResult(false, e);
+      } finally {
+        if (result != null && !result.success) {
+          for (Future<RecordMetadata> future : task.getRecordMetadataList()) {
+            if (!future.isCancelled() && !future.isDone()) {
+              future.cancel(true);
+            }
+          }
+        }
+      }
+      return result;
+    }
+  }
+
+  @VisibleForTesting
+  protected Map<Integer, KafkaWritingTaskFuture> getCommitableBuckets() {
+    return commitableBuckets;
+  }
+
+}

--- a/singer/src/main/java/com/pinterest/singer/writer/kafka/KafkaWritingTaskFuture.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/kafka/KafkaWritingTaskFuture.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.kafka;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.PartitionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * Write Task Future created for tracking partition batch write status when
+ * using {@link CommittableKafkaWriter}
+ */
+public class KafkaWritingTaskFuture {
+
+  private long firstProduceTimestamp;
+  public boolean success;
+  public Exception exception;
+  private int writtenBytesSize;
+  private int kafkaBatchWriteLatencyInMillis;
+  /**
+   * a list of the RecordMetadata for every producer record in a KafkaWritingTask.
+   * Initialization is needed to prevent NullPointerException when
+   * KafkaWritingTask fails.
+   */
+  private List<Future<RecordMetadata>> recordMetadataList = new ArrayList<>();
+  private PartitionInfo partitionInfo;
+
+  public KafkaWritingTaskFuture(PartitionInfo partitionInfo) {
+    this.partitionInfo = partitionInfo;
+  }
+
+  public KafkaWritingTaskFuture(boolean successFlag, int bytes, int kafkaLatency) {
+    this.success = successFlag;
+    this.writtenBytesSize = bytes;
+    this.kafkaBatchWriteLatencyInMillis = kafkaLatency;
+    this.exception = null;
+  }
+
+  public KafkaWritingTaskFuture(boolean successFlag, Exception e) {
+    this.success = successFlag;
+    this.exception = e;
+  }
+
+  public int getWrittenBytesSize() {
+    return writtenBytesSize;
+  }
+
+  public int getKafkaBatchWriteLatencyInMillis() {
+    return kafkaBatchWriteLatencyInMillis;
+  }
+
+  public List<Future<RecordMetadata>> getRecordMetadataList() {
+    return recordMetadataList;
+  }
+
+  public void setRecordMetadataList(List<Future<RecordMetadata>> recordMetadataList) {
+    this.recordMetadataList = recordMetadataList;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public void setSuccess(boolean success) {
+    this.success = success;
+  }
+
+  public Exception getException() {
+    return exception;
+  }
+
+  public void setException(Exception exception) {
+    this.exception = exception;
+  }
+
+  public void setWrittenBytesSize(int writtenBytesSize) {
+    this.writtenBytesSize = writtenBytesSize;
+  }
+
+  public void setKafkaBatchWriteLatencyInMillis(int kafkaBatchWriteLatencyInMillis) {
+    this.kafkaBatchWriteLatencyInMillis = kafkaBatchWriteLatencyInMillis;
+  }
+
+  public long getFirstProduceTimestamp() {
+    return firstProduceTimestamp;
+  }
+
+  public void setFirstProduceTimestamp(long firstProduceTimestamp) {
+    this.firstProduceTimestamp = firstProduceTimestamp;
+  }
+
+  public PartitionInfo getPartitionInfo() {
+    return partitionInfo;
+  }
+
+  public void setPartitionInfo(PartitionInfo partitionInfo) {
+    this.partitionInfo = partitionInfo;
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.processor;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.LogStreamReader;
+import com.pinterest.singer.common.errors.LogStreamProcessorException;
+import com.pinterest.singer.common.LogStreamWriter;
+import com.pinterest.singer.common.errors.LogStreamWriterException;
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.config.Decider;
+import com.pinterest.singer.monitor.LogStreamManager;
+import com.pinterest.singer.reader.DefaultLogStreamReader;
+import com.pinterest.singer.reader.ThriftLogFileReaderFactory;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
+import com.pinterest.singer.thrift.LogPosition;
+import com.pinterest.singer.thrift.configuration.FileNameMatchMode;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
+import com.pinterest.singer.utils.SimpleThriftLogger;
+import com.pinterest.singer.utils.WatermarkUtils;
+import com.pinterest.singer.writer.kafka.CommittableKafkaWriter;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Unit tests for {@link CommittableKafkaWriter}
+ *
+ */
+public class TestMemoryEfficientLogStreamProcessor extends com.pinterest.singer.SingerTestBase {
+
+  /**
+   * Dummy implementation of LogStreamWriter which collect all LogMessages in a
+   * list.
+   */
+  private static final class DummyLogStreamWriter implements LogStreamWriter {
+
+    private final List<LogMessage> logMessages;
+
+    private boolean throwOnWrite;
+
+    public DummyLogStreamWriter() {
+      logMessages = new ArrayList<>();
+      throwOnWrite = false;
+    }
+
+    @Override
+    public LogStream getLogStream() {
+      return null;
+    }
+
+    @Override
+    public boolean isAuditingEnabled() {
+      return false;
+    }
+
+    @Override
+    public void writeLogMessages(List<LogMessage> logMessages) throws LogStreamWriterException {
+      if (throwOnWrite) {
+        throw new LogStreamWriterException("Write error");
+      } else {
+        this.logMessages.addAll(logMessages);
+      }
+    }
+
+    @Override
+    public void startCommit() throws LogStreamWriterException {
+    }
+
+    @Override
+    public void writeLogMessageToCommit(LogMessage message) throws LogStreamWriterException {
+      if (throwOnWrite) {
+        throw new LogStreamWriterException("Write error");
+      } else {
+        this.logMessages.add(message);
+      }
+    }
+
+    @Override
+    public void endCommit(int numLogMessagesRead) throws LogStreamWriterException {
+      if (throwOnWrite) {
+        throw new LogStreamWriterException("Write error");
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    public List<LogMessage> getLogMessages() {
+      return logMessages;
+    }
+
+    public void setThrowOnWrite(boolean throwOnWrite) {
+      this.throwOnWrite = throwOnWrite;
+    }
+  }
+
+  private SingerConfig initializeSingerConfig(int processorThreadPoolSize,
+                                              int writerThreadPoolSize,
+                                              List<SingerLogConfig> singerLogConfigs) {
+    SingerConfig singerConfig = new SingerConfig();
+    singerConfig.setThreadPoolSize(1);
+    singerConfig.setWriterThreadPoolSize(1);
+    singerConfig.setLogConfigs(singerLogConfigs);
+    return singerConfig;
+  }
+
+  @Test
+  public void testProcessLogStream() throws Exception {
+    String tempPath = getTempPath();
+    String logStreamHeadFileName = "thrift.log";
+    String path = FilenameUtils.concat(tempPath, logStreamHeadFileName);
+
+    int oldestThriftLogIndex = 0;
+    int readerBufferSize = 16000;
+    int maxMessageSize = 16000;
+    int processorBatchSize = 50;
+
+    long processingIntervalInMillisMin = 1;
+    long processingIntervalInMillisMax = 1;
+    long processingTimeSliceInMilliseconds = 3600;
+    int logRetentionInSecs = 15;
+
+    // initialize a singer log config
+    SingerLogConfig logConfig = new SingerLogConfig("test", tempPath, logStreamHeadFileName, null,
+        null, null);
+    SingerLog singerLog = new SingerLog(logConfig);
+    singerLog.getSingerLogConfig().setFilenameMatchMode(FileNameMatchMode.PREFIX);
+
+    // initialize global variables in SingerSettings
+    try {
+      SingerConfig singerConfig = initializeSingerConfig(1, 1, Arrays.asList(logConfig));
+      SingerSettings.initialize(singerConfig);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("got exception in test: " + e);
+    }
+
+    // initialize log stream
+    LogStream logStream = new LogStream(singerLog, logStreamHeadFileName);
+    LogStreamManager.addLogStream(logStream);
+    SimpleThriftLogger<LogMessage> logger = new SimpleThriftLogger<>(path);
+    DummyLogStreamWriter writer = new DummyLogStreamWriter();
+
+    // initialize a log stream reader with 16K as readerBufferSize and
+    // maxMessageSize
+    LogStreamReader logStreamReader = new DefaultLogStreamReader(logStream,
+        new ThriftLogFileReaderFactory(new ThriftReaderConfig(readerBufferSize, maxMessageSize)));
+    // initialize a log stream processor that
+    MemoryEfficientLogStreamProcessor processor = new MemoryEfficientLogStreamProcessor(logStream,
+        null, logStreamReader, writer, processorBatchSize, processingIntervalInMillisMin,
+        processingIntervalInMillisMax, processingTimeSliceInMilliseconds, logRetentionInSecs);
+
+    try {
+      // Write messages to be skipped.
+      writeThriftLogMessages(logger, 150, 500, 50);
+
+      // Save start position to watermark file.
+      LogPosition startPosition = new LogPosition(logger.getLogFile(), logger.getByteOffset());
+      WatermarkUtils.saveCommittedPositionToWatermark(
+          MemoryEfficientLogStreamProcessor.getWatermarkFilename(logStream), startPosition);
+
+      List<LogMessage> messagesWritten = Lists.newArrayList();
+
+      // Rotate log file while writing messages.
+      for (int i = 0; i < 3; ++i) {
+        rotateWithDelay(logger, 1000);
+        List<LogMessageAndPosition> logMessageAndPositions = writeThriftLogMessages(logger,
+            processorBatchSize + 20, 500, 50);
+        List<LogMessage> logMessages = getMessages(logMessageAndPositions);
+        messagesWritten.addAll(logMessages);
+      }
+
+      // added to enable running this test on OS X
+      System.err.println("Waiting for file system events to be noticed by FileSystemMonitor");
+      while (logStream.isEmpty()) {
+        Thread.sleep(1000);
+        System.out.print(".");
+      }
+
+      // Process all message written so far.
+      long numOfMessageProcessed = processor.processLogStream();
+      assertEquals("Should have processed all messages written", messagesWritten.size(),
+          numOfMessageProcessed);
+      assertThat(writer.getLogMessages(), is(messagesWritten));
+
+      // Write and process a single LogMessages.
+      messagesWritten.addAll(getMessages(writeThriftLogMessages(logger, 1, 500, 50)));
+      numOfMessageProcessed = processor.processLogStream();
+      assertEquals("Should have processed a single log message", 1, numOfMessageProcessed);
+      assertThat(writer.getLogMessages(), is(messagesWritten));
+
+      // Write another set of LogMessages.
+      messagesWritten
+          .addAll(getMessages(writeThriftLogMessages(logger, processorBatchSize + 1, 500, 50)));
+
+      // Writer will throw on write.
+      writer.setThrowOnWrite(true);
+      LogPosition positionBefore = WatermarkUtils.loadCommittedPositionFromWatermark(
+          MemoryEfficientLogStreamProcessor.getWatermarkFilename(logStream));
+      try {
+        processor.processLogStream();
+        fail("No exception is thrown on writer error");
+      } catch (LogStreamProcessorException e) {
+        // Exception is thrown.
+      }
+      LogPosition positionAfter = WatermarkUtils.loadCommittedPositionFromWatermark(
+          MemoryEfficientLogStreamProcessor.getWatermarkFilename(logStream));
+      assertEquals(positionBefore, positionAfter);
+
+      // Write will not throw on write.
+      writer.setThrowOnWrite(false);
+      numOfMessageProcessed = processor.processLogStream();
+      assertEquals("Should not have processed any additional messages", processorBatchSize + 1,
+          numOfMessageProcessed);
+      assertThat(writer.getLogMessages(), is(messagesWritten));
+
+      // Rotate and write twice before processing
+      rotateWithDelay(logger, 1000);
+      boolean successfullyAdded = messagesWritten
+          .addAll(getMessages(writeThriftLogMessages(logger, processorBatchSize - 20, 500, 50)));
+      assertTrue(successfullyAdded);
+      rotateWithDelay(logger, 1000);
+      successfullyAdded = messagesWritten
+          .addAll(getMessages(writeThriftLogMessages(logger, processorBatchSize, 500, 50)));
+      assertTrue(successfullyAdded);
+
+      // Need to wait for some time to make sure that messages have been written to
+      // disk
+      Thread.sleep(FILE_EVENT_WAIT_TIME_MS);
+      numOfMessageProcessed = processor.processLogStream();
+
+      Thread.sleep(FILE_EVENT_WAIT_TIME_MS);
+      processor.processLogStream();
+
+      assertEquals(2 * processorBatchSize - 20, numOfMessageProcessed);
+      assertThat(writer.getLogMessages(), is(messagesWritten));
+      processor.processLogStream();
+      String oldThriftLogPath = FilenameUtils.concat(getTempPath(),
+          "thrift.log." + oldestThriftLogIndex);
+      File oldThriftLog = new File(oldThriftLogPath);
+      assertFalse(oldThriftLog.exists()); // the oldest file is at least 10 seconds old now
+      // oldThriftLogPath = FilenameUtils.concat(getTempPath(),
+      // "thrift.log." + (oldestThriftLogIndex - 1));
+      // oldThriftLog = new File(oldThriftLogPath);
+      assertFalse(oldThriftLog.exists()); // the next oldest file is at least 9 seconds old now
+      assertTrue(new File(path).exists()); // make sure the newest log file is still there
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Got exception in test");
+    } finally {
+      logger.close();
+      processor.close();
+    }
+  }
+
+  @Test
+  public void testProcessLogStreamWithDecider() throws Exception {
+    MemoryEfficientLogStreamProcessor processor = null;
+    try {
+      SingerConfig singerConfig = new SingerConfig();
+      singerConfig.setThreadPoolSize(1);
+      singerConfig.setWriterThreadPoolSize(1);
+      SingerSettings.initialize(singerConfig);
+      SingerLog singerLog = new SingerLog(
+          new SingerLogConfig("test", getTempPath(), "thrift.log", null, null, null));
+      LogStream logStream = new LogStream(singerLog, "thrift.log");
+      DummyLogStreamWriter writer = new DummyLogStreamWriter();
+      processor = new MemoryEfficientLogStreamProcessor(logStream, "singer_test_decider",
+          new DefaultLogStreamReader(logStream,
+              new ThriftLogFileReaderFactory(new ThriftReaderConfig(16000, 16000))),
+          writer, 50, 1, 1, 3600, 1800);
+      Decider.setInstance(ImmutableMap.of("singer_test_decider", 0));
+      // Write messages to be skipped.
+      boolean deciderEnabled = processor.isLoggingAllowedByDecider();
+      assertEquals(false, deciderEnabled);
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Unexpected exception");
+    } finally {
+      if (processor != null) {
+        processor.close();
+      }
+    }
+  }
+
+  private static List<LogMessage> getMessages(List<LogMessageAndPosition> messageAndPositions) {
+    List<LogMessage> messages = Lists.newArrayListWithExpectedSize(messageAndPositions.size());
+    for (LogMessageAndPosition messageAndPosition : messageAndPositions) {
+      messages.add(messageAndPosition.getLogMessage());
+    }
+    return messages;
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/kafka/TestCommittableKafkaWriter.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/kafka/TestCommittableKafkaWriter.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright 2020 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.kafka;
+
+import static org.mockito.Mockito.when;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.pulsar.shade.org.apache.commons.lang3.concurrent.ConcurrentUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
+import com.pinterest.singer.SingerTestBase;
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+import com.pinterest.singer.writer.Crc32ByteArrayPartitioner;
+import com.pinterest.singer.writer.KafkaMessagePartitioner;
+import com.pinterest.singer.writer.KafkaProducerManager;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestCommittableKafkaWriter extends SingerTestBase {
+
+  private static final int NUM_EVENTS = 1000;
+
+  private static final int NUM_KEYS = 20;
+
+  @Mock
+  KafkaProducer<byte[], byte[]> producer;
+
+  @Test
+  public void testWriteLogMessagesWithCrcPartitioning() throws Exception {
+    KafkaMessagePartitioner partitioner = new Crc32ByteArrayPartitioner();
+    KafkaProducerConfig config = new KafkaProducerConfig();
+    SingerSettings.setSingerConfig(new SingerConfig());
+    KafkaProducerManager.injectTestProducer(config, producer);
+    // default value for skip noleader partition is false
+    CommittableKafkaWriter writer = new CommittableKafkaWriter(config, partitioner, "topicx", false,
+        Executors.newCachedThreadPool());
+
+    List<PartitionInfo> partitions = ImmutableList.copyOf(Arrays.asList(
+        new PartitionInfo("topicx", 1, new Node(2, "broker2", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 0, new Node(1, "broker1", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 2, new Node(3, "broker3", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topicx", 6, new Node(2, "broker2", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 3, new Node(4, "broker4", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 5, new Node(1, "broker1", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 7, new Node(3, "broker3", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topicx", 4, new Node(5, "broker5", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 8, new Node(4, "broker4", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topicx", 9, new Node(5, "broker5", 9092, "us-east-1b"), null, null),
+        new PartitionInfo("topicx", 10, new Node(1, "broker1", 9092, "us-east-1a"), null, null)));
+
+    when(producer.partitionsFor("topicx")).thenReturn(partitions);
+
+    // message with same key will be put together in the same bucket (same
+    // partition);
+    List<String> keys = IntStream.range(0, NUM_KEYS).mapToObj(i -> "key" + i)
+        .collect(Collectors.toList());
+    Map<Integer, List<LogMessage>> msgPartitionMap = new HashMap<>();
+    Map<Integer, List<ProducerRecord<byte[], byte[]>>> recordPartitionMap = new HashMap<>();
+    Map<Integer, List<RecordMetadata>> metadataPartitionMap = new HashMap<>();
+    HashFunction crc32 = Hashing.crc32();
+    List<LogMessage> logMessages = new ArrayList<>();
+    for (int i = 0; i < NUM_KEYS; i++) {
+      for (int j = 0; j < NUM_EVENTS / NUM_KEYS; j++) {
+        LogMessage logMessage = new LogMessage();
+        logMessage.setKey(keys.get(i).getBytes());
+        int messageId = logMessages.size();
+        ByteBuffer buf = ByteBuffer.allocate(4).putInt(messageId);
+        buf.flip();
+        logMessage.setMessage(buf);
+        logMessages.add(logMessage);
+        int partitionId = Math
+            .abs(crc32.hashBytes(logMessage.getKey()).asInt() % partitions.size());
+        ProducerRecord<byte[], byte[]> record = new ProducerRecord<byte[], byte[]>("topicx",
+            partitionId, logMessage.getKey(), logMessage.getMessage());
+        RecordMetadata recordMetadata = new RecordMetadata(
+            new TopicPartition(record.topic(), record.partition()), messageId, 0, 0, 0L,
+            record.key().length, record.value().length);
+        when(producer.send(record)).thenReturn(ConcurrentUtils.constantFuture(recordMetadata));
+
+        if (msgPartitionMap.containsKey(partitionId)) {
+          msgPartitionMap.get(partitionId).add(logMessage);
+          recordPartitionMap.get(partitionId).add(record);
+          metadataPartitionMap.get(partitionId).add(recordMetadata);
+        } else {
+          msgPartitionMap.put(partitionId, new ArrayList<>());
+          recordPartitionMap.put(partitionId, new ArrayList<>());
+          metadataPartitionMap.put(partitionId, new ArrayList<>());
+          msgPartitionMap.get(partitionId).add(logMessage);
+          recordPartitionMap.get(partitionId).add(record);
+          metadataPartitionMap.get(partitionId).add(recordMetadata);
+        }
+      }
+    }
+
+    writer.startCommit();
+
+    for (LogMessage msg : logMessages) {
+      writer.writeLogMessageToCommit(msg);
+    }
+    Map<Integer, KafkaWritingTaskFuture> commitableBuckets = writer.getCommitableBuckets();
+    for (int partitionId = 0; partitionId < partitions.size(); partitionId++) {
+      KafkaWritingTaskFuture kafkaWritingTaskFuture = commitableBuckets.get(partitionId);
+      List<Future<RecordMetadata>> recordMetadataList = kafkaWritingTaskFuture
+          .getRecordMetadataList();
+      if (recordMetadataList.size() == 0) {
+        continue;
+      }
+      int partition = kafkaWritingTaskFuture.getPartitionInfo().partition();
+
+      // verify the message order is what is expected by calling messageCollation()
+      List<ProducerRecord<byte[], byte[]>> expectedRecords = recordPartitionMap.get(partitionId);
+      assertEquals(expectedRecords.size(), recordMetadataList.size());
+      for (int j = 0; j < recordMetadataList.size(); j++) {
+        RecordMetadata md = recordMetadataList.get(j).get();
+        ProducerRecord<byte[], byte[]> producerRecord = expectedRecords.get(j);
+        // validate that the message id expected is correct partition
+        assertEquals(partition, (int) producerRecord.partition());
+        assertEquals(ByteBuffer.wrap(producerRecord.value()).getInt(), md.offset());
+      }
+
+    }
+
+    writer.endCommit(logMessages.size());
+    // validate if writes are throwing any error
+    writer.close();
+  }
+
+  @Test
+  public void testWriterWithHeadersInjectorEnabledWithWrongClass() throws Exception {
+    SingerLog singerLog = new SingerLog(createSingerLogConfig("test", "/a/b/c"));
+    LogStream logStream = new LogStream(singerLog, "test.tmp");
+    KafkaMessagePartitioner partitioner = new Crc32ByteArrayPartitioner();
+    KafkaProducerConfig config = new KafkaProducerConfig();
+    SingerSettings.setSingerConfig(new SingerConfig());
+    KafkaProducerManager.injectTestProducer(config, producer);
+    // set wrong headerInjectorClass name, headerInjector will be null if
+    // enableHeaderInjector is true
+    logStream.getSingerLog().getSingerLogConfig().setHeadersInjectorClass("com.pinterest.x.y.z");
+    @SuppressWarnings("resource")
+    CommittableKafkaWriter writer = new CommittableKafkaWriter(logStream, config, partitioner,
+        "topicx", false, Executors.newCachedThreadPool(), true);
+    assertNull(writer.getHeadersInjector());
+  }
+}


### PR DESCRIPTION
New MemoryEfficientLogStreamProcessor to reduce memory utilization. 

**Description:**
Singer currently uses a micro-batch processing architecture which relies on in-memory buffering of data using List. This design requires substantial memory usage as all data need to be first loaded in memory instead of being directly available for streaming.

This change creates an iterator like design pattern that can be leveraged to stream data directly to the writer and let the writer create and ship micro-batches as needed. This allows only 1 LogMessage object to be buffered in memory instead of 10s or 100s (depending on configured logstream batch sizes) making Singer substantially more scalable and allowing it to ship more data without consuming more resources.

**Configurations:**
The new processor can be configured on a per LogStream basis to reduce impact and enable selective rollout.

**Test Setup:**
Using random log generation application generating thrift logs, thrift log files of 2GB were created. 
- Total logs: 2GB
- Message size: 5-8KB
- Message contents: UUID.randomUUID() + text data
- Destination: Kafka (same cluster)
- Reader Type: thrift
- Processing Batch size: 10K
- Processing Frequency: 2s

Multiple runs were performed to capture the Singer gc log data to confirm the active heap utilization. In each case Singer was started with 800MB of heap (-Xms800m -Xmx800m)

**Test Results:**
Old version of singer (regular)
Heap usage (min): 250-300MB
Heap usage (max): 600MB

New version of singer (shadow mode)
Heap usage (min): 25MB
Heap usage (max): 30MB

Utilization memory is proportional to the size of the Kafka buffer.memory which can be further optimized as needed.