### PR TITLE
Trim last newline character for text log reader in Singer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.15</version>
+    <version>0.8.0.16</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.15</version>
+    <version>0.8.0.16</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -57,6 +57,8 @@ struct TextReaderConfig {
   7: optional bool prependHostname = false;
   // the delimiter for prepended messages
   8: optional string prependFieldDelimiter = " ";
+  // ability to trim trailing new line character
+  9: optional bool trimTailingNewlineCharacter = false;
 }
 
 struct LogStreamReaderConfig {

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.15</version>
+        <version>0.8.0.16</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
@@ -61,6 +61,7 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
           readerConfig.getTextLogMessageType(),
           readerConfig.isPrependTimestamp(),
           readerConfig.isPrependHostname(),
+          readerConfig.isTrimTailingNewlineCharacter(),
           SingerUtils.getHostNameBasedOnConfig(logStream, SingerSettings.getSingerConfig()),
           readerConfig.getPrependFieldDelimiter());
     } catch (LogFileReaderException e) {

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -911,6 +911,12 @@ public class LogConfigUtils {
         config.setPrependFieldDelimiter(str);
       }
     }
+    
+    if (textReaderConfiguration.containsKey("trimTailingNewlineCharacter")) {
+      boolean trimTailingNewlineCharacter = textReaderConfiguration
+          .getBoolean("trimTailingNewlineCharacter");
+      config.setTrimTailingNewlineCharacter(trimTailingNewlineCharacter);
+    }
     return config;
   }
 

--- a/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
@@ -43,10 +43,10 @@ public class TestTextLogFileReader extends SingerTestBase {
     long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
     LogFile logFile = new LogFile(inode);
     LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 1,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null, null);
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, null, null);
     for (int i = 0; i < 100; i++) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
-      assertEquals(dataWritten.get(i), new String(log.getLogMessage().getMessage()));
+      assertEquals(dataWritten.get(i).trim(), new String(log.getLogMessage().getMessage()));
     }
     reader.close();
   }
@@ -61,10 +61,13 @@ public class TestTextLogFileReader extends SingerTestBase {
     long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
     LogFile logFile = new LogFile(inode);
     LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 1,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, true, hostname, delimiter);
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, true, false, hostname, delimiter);
     for (int i = 0; i < 100; i++) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
-      assertEquals(hostname + delimiter + dataWritten.get(i), new String(log.getLogMessage().getMessage()));
+      String expected = hostname + delimiter + dataWritten.get(i);
+      String observed = new String(log.getLogMessage().getMessage());
+      assertEquals(expected.length(), observed.length());
+      assertEquals(expected, observed);
     }
     reader.close();
   }
@@ -77,10 +80,10 @@ public class TestTextLogFileReader extends SingerTestBase {
     long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
     LogFile logFile = new LogFile(inode);
     LogFileReader reader = new TextLogFileReader(logFile, path, 0, 8192, 102400, 2,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, null, null);
+        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, null, null);
     for (int i = 0; i < 100; i = i + 2) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
-      assertEquals(dataWritten.get(i) + dataWritten.get(i + 1),
+      assertEquals(dataWritten.get(i) + dataWritten.get(i + 1).trim(),
           new String(log.getLogMessage().getMessage()));
     }
     assertNull(reader.readLogMessageAndPosition());

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.15</version>
+    <version>0.8.0.16</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Trim last newline character for text log reader in Singer.

This configuration is activated using 

```
reader.text.trimTailingNewlineCharacter=true
```

Default is false.

Singer version 0.8.0.16