### PR TITLE
Allow custom environment variables to be injected in text logs based on config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.17</version>
+    <version>0.8.0.18</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.17</version>
+    <version>0.8.0.18</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -59,6 +59,8 @@ struct TextReaderConfig {
   8: optional string prependFieldDelimiter = " ";
   // ability to trim trailing new line character
   9: optional bool trimTailingNewlineCharacter = false;
+  // custom environment variables to be injected into text logs
+  10:optional string prependEnvironmentVariableString;
 }
 
 struct LogStreamReaderConfig {

--- a/singer-commons/src/main/thrift/text_message.thrift
+++ b/singer-commons/src/main/thrift/text_message.thrift
@@ -7,4 +7,5 @@ struct TextMessage {
   1: required list<string> messages;
   2: optional string host;
   3: optional string filename;
+  4: optional string prependEnvironmentVariables;
 }

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.17</version>
+        <version>0.8.0.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -58,6 +58,8 @@ public class TextLogFileReader implements LogFileReader {
 
   private boolean trimTailingNewlineCharacter;
 
+  private String prependEnvironmentVariables;
+
   public TextLogFileReader(LogFile logFile,
                            String path,
                            long byteOffset,
@@ -70,7 +72,8 @@ public class TextLogFileReader implements LogFileReader {
                            boolean prependHostName,
                            boolean trimTailingNewlineCharacter,
                            String hostname,
-                           String prependFieldDelimiter) throws Exception {
+                           String prependFieldDelimiter,
+                           String prependEnvironmentVariables) throws Exception {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(path));
     Preconditions.checkArgument(byteOffset >= 0);
 
@@ -86,6 +89,7 @@ public class TextLogFileReader implements LogFileReader {
     this.prependTimestamp = prependTimestamp;
     this.prependHostname = prependHostName;
     this.prependFieldDelimiter = prependFieldDelimiter;
+    this.prependEnvironmentVariables = prependEnvironmentVariables;
     this.maxBuffer = ByteBuffer.allocate(maxMessageSize * numMessagesPerLogMessage);
     this.trimTailingNewlineCharacter = trimTailingNewlineCharacter;
 
@@ -127,6 +131,9 @@ public class TextLogFileReader implements LogFileReader {
         }
         if (prependHostname) {
           prependStr += hostname + prependFieldDelimiter;
+        }
+        if (prependEnvironmentVariables != null) {
+          prependStr += prependEnvironmentVariables;
         }
         if (prependStr.length() > 0) {
           maxBuffer.put(prependStr.getBytes());

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
@@ -63,7 +63,8 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
           readerConfig.isPrependHostname(),
           readerConfig.isTrimTailingNewlineCharacter(),
           SingerUtils.getHostNameBasedOnConfig(logStream, SingerSettings.getSingerConfig()),
-          readerConfig.getPrependFieldDelimiter());
+          readerConfig.getPrependFieldDelimiter(),
+          readerConfig.getPrependEnvironmentVariableString());
     } catch (LogFileReaderException e) {
       LOG.warn("Exception in getLogFileReader", e);
       long inode = logFile.getInode();

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -964,6 +964,23 @@ public class LogConfigUtils {
       }
     }
     
+    if (textReaderConfiguration.containsKey("prependEnvironmentVariables")) {
+      String str = textReaderConfiguration.getString("prependEnvironmentVariables");
+      String[] variables = str.split(",");
+      StringBuilder builder = new StringBuilder();
+      for (String variable : variables) {
+        String env = System.getenv(variable);
+        builder.append(variable + "=");
+        if (env != null) {
+          builder.append(env);
+        } else {
+          builder.append("-");
+        }
+        builder.append(config.getPrependFieldDelimiter());
+      }
+      config.setPrependEnvironmentVariableString(builder.toString());
+    }
+    
     if (textReaderConfiguration.containsKey("trimTailingNewlineCharacter")) {
       boolean trimTailingNewlineCharacter = textReaderConfiguration
           .getBoolean("trimTailingNewlineCharacter");

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.17</version>
+    <version>0.8.0.18</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Allow custom environment variables to be injected in text logs based on config.

This can be provided via config of comma separated list:
```
reader.text.prependEnvironmentVariables=USER,HOST
```

Output will contain materialized values of these environment variables; if the variable is null `-` will be added.

Output
`|USER=xyz HOST=abc|`