### PR TITLE
Add crc features for thrift-logger and singer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.21</version>
+    <version>0.8.0.22</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.21</version>
+    <version>0.8.0.22</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/common/LoggingAuditClientConfigDef.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/common/LoggingAuditClientConfigDef.java
@@ -30,6 +30,7 @@ public class LoggingAuditClientConfigDef {
   public static final String SAMPLING_RATE = "samplingRate";
   public static final String START_AT_CURRENT_STAGE = "startAtCurrentStage";
   public static final String STOP_AT_CURRENT_STAGE = "stopAtCurrentStage";
+  public static final String SKIP_CORRUPTED_MESSAGE_AT_CURRENT_STAGE = "skipCorruptedMessageAtCurrentStage";
 
 
   public static final String SENDER_PREFIX = "sender.";

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/utils/ConfigUtils.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/utils/ConfigUtils.java
@@ -194,6 +194,11 @@ public class ConfigUtils {
             .setStopAtCurrentStage(
                 conf.getBoolean(LoggingAuditClientConfigDef.STOP_AT_CURRENT_STAGE));
       }
+      if (conf.containsKey(LoggingAuditClientConfigDef.SKIP_CORRUPTED_MESSAGE_AT_CURRENT_STAGE)) {
+        topicAuditConfig
+                .setSkipCorruptedMessageAtCurrentStage(
+                        conf.getBoolean(LoggingAuditClientConfigDef.SKIP_CORRUPTED_MESSAGE_AT_CURRENT_STAGE));
+      }
       return topicAuditConfig;
     } catch (Exception e) {
       throw new ConfigurationException("Can't create TopicAuditConfig from configuration.", e);

--- a/singer-commons/src/main/thrift/loggingaudit_config.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit_config.thrift
@@ -56,6 +56,11 @@ struct AuditConfig{
     *  true at Merced / Merced_HR stage.
     */
     3: optional bool stopAtCurrentStage = false;
+
+    /**
+    *   flag indicates whether to skip corrupted messages at the current stage or not
+    */
+    4: optional bool skipCorruptedMessageAtCurrentStage = false;
 }
 
 

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.21</version>
+        <version>0.8.0.22</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -105,6 +105,9 @@ public class SingerMetrics {
   public static final String AUDIT_HEADERS_INJECTED = "singer.audit.num_of_headers_injected";
   public static final String AUDIT_HEADERS_METADATA_COUNT_MISMATCH = "singer.audit.headers_metadata_count_mismatch";
   public static final String AUDIT_HEADERS_METADATA_COUNT_MATCH = "singer.audit.headers_metadata_count_match";
+  public static final String NUM_CORRUPTED_MESSAGES = "singer.audit.num_corrupted_messages";
+  public static final String NUM_CORRUPTED_MESSAGES_SKIPPED = "singer.audit.num_corrupted_messages_skipped";
+
 
   // Used when logging audit is enabled and is started at Singer instead of ThriftLogger.
   public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE = "singer.audit.log_message_headers_set";

--- a/singer/src/main/java/com/pinterest/singer/writer/HeadersInjector.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/HeadersInjector.java
@@ -15,7 +15,6 @@
  */
 package com.pinterest.singer.writer;
 
-import com.pinterest.singer.thrift.LogMessage;
 import org.apache.kafka.common.header.Headers;
 
 /**
@@ -26,11 +25,10 @@ import org.apache.kafka.common.header.Headers;
 public interface HeadersInjector {
 
   /**
-   * Given ProducerRecord's Headers object and LogMessage object
+   * Given ProducerRecord's Headers object and String key and byte[] value
    *
    * @return The original ProducerRecord's Headers object with some headers added.
    */
-
-   Headers addHeaders(Headers headers, LogMessage logMessage);
+   Headers addHeaders(Headers headers, String key, byte[] value);
 
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/headersinjectors/LoggingAuditHeadersInjector.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/headersinjectors/LoggingAuditHeadersInjector.java
@@ -1,13 +1,8 @@
 package com.pinterest.singer.writer.headersinjectors;
 
-import com.pinterest.singer.common.SingerMetrics;
-import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.writer.HeadersInjector;
 
-import com.twitter.ostrich.stats.Stats;
 import org.apache.kafka.common.header.Headers;
-import org.apache.thrift.TException;
-import org.apache.thrift.TSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,22 +13,10 @@ import org.slf4j.LoggerFactory;
 public class LoggingAuditHeadersInjector implements HeadersInjector {
 
   private static final Logger LOG = LoggerFactory.getLogger(LoggingAuditHeadersInjector.class);
-  private static final String HEADER_KEY = "loggingAuditHeaders";
-
-  private final TSerializer SER = new TSerializer();
-
-  public static String getHeaderKey() {
-    return HEADER_KEY;
-  }
 
   @Override
-  public Headers addHeaders(Headers headers, LogMessage logMessage) {
-    try {
-      headers.add(HEADER_KEY, SER.serialize(logMessage.getLoggingAuditHeaders()));
-    } catch (TException e) {
-      Stats.incr(SingerMetrics.NUMBER_OF_SERIALIZING_HEADERS_ERRORS);
-      LOG.warn("Exception thrown while serializing loggingAuditHeaders", e);
-    }
+  public Headers addHeaders(Headers headers, String key, byte[] value) {
+    headers.add(key, value);
     return headers;
   }
 }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.21</version>
+    <version>0.8.0.22</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>

--- a/thrift-logger/src/main/java/com/pinterest/singer/client/LogbackThriftLogger.java
+++ b/thrift-logger/src/main/java/com/pinterest/singer/client/LogbackThriftLogger.java
@@ -46,6 +46,8 @@ public class LogbackThriftLogger extends BaseThriftLogger {
       int firstDotPos = hostName.indexOf('.');
       if (firstDotPos > 0) {
         HOST_NAME = hostName.substring(0, firstDotPos);
+      } else {
+        HOST_NAME = hostName;
       }
     } catch (Exception e) {
       // fall back to env var.


### PR DESCRIPTION
1. For thrift-logger, add crc feature by computing and setting the checksum field of the LogMessage
2. For singer, add crc feature in KafkaWriter.java and CommittableKafkaWriter.java, and inject the crc checksum as a header of the ProducerRecord