### PR TITLE
Add message key/value size metric in the processor

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -58,6 +58,9 @@ public class SingerMetrics {
 
   public static final String CURRENT_PROCESSOR_LATENCY = "current.processor.latency";
 
+  public static final String PROCESSOR_MESSAGE_KEY_SIZE_BYTES = "processor.message.key.size.bytes";
+  public static final String PROCESSOR_MESSAGE_VALUE_SIZE_BYTES = "processor.message.value.size.bytes";
+
   public static final String SKIPPED_BYTES = "singer.reader.skipped_bytes";
 
   public static final String WATERMARK_CREATION_FAILURE = "singer.watermark.creation.failure";

--- a/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
@@ -17,6 +17,9 @@ package com.pinterest.singer.processor;
 
 import java.io.IOException;
 
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.utils.SingerUtils;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,7 +99,18 @@ public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor
         // because there is some data to read we need to prepare the commit
         writer.startCommit();
       }
-      writer.writeLogMessageToCommit(message.getLogMessage());
+      LogMessage logMessage = message.getLogMessage();
+      OpenTsdbMetricConverter.gauge(
+              SingerMetrics.PROCESSOR_MESSAGE_KEY_SIZE_BYTES,
+              logMessage.getKey().length,
+              "log=" + logStream.getLogStreamName(),
+              "host=" + SingerUtils.getHostname());
+      OpenTsdbMetricConverter.gauge(
+              SingerMetrics.PROCESSOR_MESSAGE_VALUE_SIZE_BYTES,
+              logMessage.getMessage().length,
+              "log=" + logStream.getLogStreamName(),
+              "host=" + SingerUtils.getHostname());
+      writer.writeLogMessageToCommit(logMessage);
     }
 
     if (logMessagesRead > 0) {


### PR DESCRIPTION
`processor.message.key.size.bytes`
`processor.message.value.size.bytes`

Current implementation sends two metrics per message. If this could cause stress on the metrics processing side, we could easily change it to send two aggregate metrics per batch of messages.