### PR TITLE
Cleanup unnecessary Singer dependencies to make binary more efficient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.31</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.31</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>
@@ -59,11 +59,6 @@
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
       <version>1.9</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.11</artifactId>
-      <version>${kafka.client.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.29</version>
+        <version>0.8.0.31</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>
@@ -73,11 +73,6 @@
             <version>0.0.115</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.twitter.common/dynamic-host-set -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.11</artifactId>
-            <version>2.1.0</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
@@ -184,6 +179,7 @@
             <groupId>org.apache.pulsar</groupId>
             <artifactId>pulsar-client</artifactId>
             <version>2.3.2</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.31</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Cleanup unnecessary Singer dependencies to make binary more efficient. Singer 0.8.0.30

- Marking Pulsar dependencies as provided so anyone deploying Singer with Pulsar can optionally add those; this saves over 15MB deployment size
- Removing unnecessary dependency on Kafka server