### PR TITLE
comment out the size metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.30</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.30</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.29</version>
+        <version>0.8.0.30</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -550,6 +550,9 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
     }
     List<LogMessage> logMessagesToWrite = Lists.newArrayListWithExpectedSize(numMessages);
     for (LogMessageAndPosition logMessageRead : logMessagesRead) {
+      logMessagesToWrite.add(logMessageRead.getLogMessage());
+
+      /* TODO: Setting the host tag of these two metrics need to be optimized.
       LogMessage logMessage = logMessageRead.getLogMessage();
       logMessagesToWrite.add(logMessage);
       OpenTsdbMetricConverter.gauge(
@@ -562,6 +565,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
               logMessage.isSetMessage() ? logMessage.getMessage().length : 0,
               "log=" + logStream.getSingerLog().getSingerLogConfig().getName(),
               "host=" + SingerUtils.getHostname());
+      */
     }
     writer.writeLogMessages(logMessagesToWrite);
     LogMessage lastMessage = logMessagesToWrite.get(numMessages - 1);

--- a/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
@@ -99,6 +99,8 @@ public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor
         // because there is some data to read we need to prepare the commit
         writer.startCommit();
       }
+      writer.writeLogMessageToCommit(message.getLogMessage());
+      /* TODO:  Setting the host tag of these two metrics need to be optimized.
       LogMessage logMessage = message.getLogMessage();
       OpenTsdbMetricConverter.gauge(
               SingerMetrics.PROCESSOR_MESSAGE_KEY_SIZE_BYTES,
@@ -111,6 +113,7 @@ public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor
               "log=" + logStream.getSingerLog().getSingerLogConfig().getName(),
               "host=" + SingerUtils.getHostname());
       writer.writeLogMessageToCommit(logMessage);
+      */
     }
 
     if (logMessagesRead > 0) {

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.29</version>
+    <version>0.8.0.30</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
This PR commented out the size metrics added for LogMessage in https://github.com/pinterest/singer/pull/81. 

The host tag is set by calling getHostName() in SingerUtils.java and this can be optimized to reduce CPU cycles.