### PR TITLE
Refactor Singer to enable writers to access LogMessageAndPosition to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.31</version>
+    <version>0.8.0.32</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.31</version>
+    <version>0.8.0.32</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.31</version>
+        <version>0.8.0.32</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/LogStreamWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/common/LogStreamWriter.java
@@ -17,6 +17,7 @@ package com.pinterest.singer.common;
 
 import com.pinterest.singer.common.errors.LogStreamWriterException;
 import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
 
 import java.io.Closeable;
 import java.util.List;
@@ -63,10 +64,10 @@ public interface LogStreamWriter extends Closeable {
    * Send 1 LogMessage to the writer, note that writer is expected to not finalize
    * the messages until the commit method is invoked
    * 
-   * @param message
+   * @param logMessageAndPosition
    * @throws LogStreamWriterException
    */
-  default void writeLogMessageToCommit(LogMessage message) throws LogStreamWriterException {
+  default void writeLogMessageToCommit(LogMessageAndPosition logMessageAndPosition) throws LogStreamWriterException {
     throw new UnsupportedOperationException();
   }
 

--- a/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
@@ -44,6 +44,7 @@ import com.pinterest.singer.common.errors.LogStreamWriterException;
 import com.pinterest.singer.loggingaudit.thrift.LoggingAuditHeaders;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
 import com.pinterest.singer.thrift.configuration.SingerRestartConfig;
 import com.pinterest.singer.writer.KafkaMessagePartitioner;
@@ -149,7 +150,8 @@ public class CommittableKafkaWriter extends KafkaWriter {
   }
 
   @Override
-  public void writeLogMessageToCommit(LogMessage msg) throws LogStreamWriterException {
+  public void writeLogMessageToCommit(LogMessageAndPosition messageAndPosition) throws LogStreamWriterException {
+    LogMessage msg = messageAndPosition.getLogMessage();
     ProducerRecord<byte[], byte[]> keyedMessage;
     byte[] key = null;
     if (msg.isSetKey()) {

--- a/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
@@ -95,11 +95,11 @@ public class TestMemoryEfficientLogStreamProcessor extends com.pinterest.singer.
     }
 
     @Override
-    public void writeLogMessageToCommit(LogMessage message) throws LogStreamWriterException {
+    public void writeLogMessageToCommit(LogMessageAndPosition logMessageAndPosition) throws LogStreamWriterException {
       if (throwOnWrite) {
         throw new LogStreamWriterException("Write error");
       } else {
-        this.logMessages.add(message);
+        this.logMessages.add(logMessageAndPosition.getLogMessage());
       }
     }
 

--- a/singer/src/test/java/com/pinterest/singer/writer/kafka/TestCommittableKafkaWriter.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/kafka/TestCommittableKafkaWriter.java
@@ -56,6 +56,7 @@ import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.loggingaudit.thrift.LoggingAuditHeaders;
 import com.pinterest.singer.thrift.LogMessage;
+import com.pinterest.singer.thrift.LogMessageAndPosition;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.writer.Crc32ByteArrayPartitioner;
@@ -142,7 +143,8 @@ public class TestCommittableKafkaWriter extends SingerTestBase {
     writer.startCommit();
 
     for (LogMessage msg : logMessages) {
-      writer.writeLogMessageToCommit(msg);
+      LogMessageAndPosition pos = new LogMessageAndPosition(msg, null);
+      writer.writeLogMessageToCommit(pos);
     }
     Map<Integer, KafkaWritingTaskFuture> commitableBuckets = writer.getCommitableBuckets();
     for (int partitionId = 0; partitionId < partitions.size(); partitionId++) {
@@ -260,7 +262,8 @@ public class TestCommittableKafkaWriter extends SingerTestBase {
     writer.startCommit();
 
     for (LogMessage msg : logMessages) {
-      writer.writeLogMessageToCommit(msg);
+      LogMessageAndPosition pos = new LogMessageAndPosition(msg, null);
+      writer.writeLogMessageToCommit(pos);
     }
     Map<Integer, KafkaWritingTaskFuture> commitableBuckets = writer.getCommitableBuckets();
     for (int partitionId = 0; partitionId < partitions.size(); partitionId++) {
@@ -394,7 +397,8 @@ public class TestCommittableKafkaWriter extends SingerTestBase {
     writer.startCommit();
 
     for (LogMessage msg : logMessages) {
-      writer.writeLogMessageToCommit(msg);
+      LogMessageAndPosition pos = new LogMessageAndPosition(msg, null);
+      writer.writeLogMessageToCommit(pos);
     }
     Map<Integer, KafkaWritingTaskFuture> commitableBuckets = writer.getCommitableBuckets();
     int numMessagesWritten = 0;
@@ -445,7 +449,8 @@ public class TestCommittableKafkaWriter extends SingerTestBase {
     writer.startCommit();
 
     for (LogMessage msg : logMessages) {
-      writer.writeLogMessageToCommit(msg);
+      LogMessageAndPosition pos = new LogMessageAndPosition(msg, null);
+      writer.writeLogMessageToCommit(pos);
     }
     Map<Integer, KafkaWritingTaskFuture> commitableBuckets = writer.getCommitableBuckets();
     int numMessagesWritten = 0;

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.31</version>
+    <version>0.8.0.32</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Refactor Singer to enable writers to access LogMessageAndPosition to allow logmessages to be tracked.
This enables Singer writers to have unique id for every logmessage which can be used for sequencing / auditing etc.

Singer 0.8.0.32

Message sequencing could be critical to a Logging infrastructure, for example its one of the reasons customers in Kafka opt to use key partitioning. Singer has the assets to make sequencing a first class citizen but doesn’t do that today.

Sequencing & Iding:
Sequencing and Identification of a unique message is critical to allow the ability to be able to track / audit it through the pipeline. Luckily because we use thrift logger we can create a unique sequence by using the following tuple:
```<generating host ip><inode><offset>```
This tuple allows us to uniquely identify a message in our Logging Systems. If a writer wants to it could use it for a variety of purposes.

New Singer design change, change interface for Writer from
void writeLogMessageToCommit(LogMessage message)
TO
void writeLogMessageToCommit(LogMessageAndPosition logMessageAndPosition)
Enabling writers to generate the message ID.
