### PR TITLE
Multiple improvements to thrift-logger module and singer-commons module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.36</version>
+    <version>0.8.0.37</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.36</version>
+    <version>0.8.0.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditClient.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditClient.java
@@ -153,6 +153,20 @@ public class LoggingAuditClient {
   /**
    *  create and enqueue a LoggingAuditEvent if TopicAuditConfig exists for this topic/logName,
    *  enqueueEnabled is true and there is capacity available in the queue.
+   * @param loggingAuditHeaders
+   * @param messageValid
+   * @param messageAcknowledgedTimestamp
+   * @param messageSkipped
+   */
+  public void audit(String loggingAuditName, LoggingAuditHeaders loggingAuditHeaders,
+                    boolean messageValid, long messageAcknowledgedTimestamp, boolean messageSkipped) {
+    audit(loggingAuditName, loggingAuditHeaders, messageValid, messageAcknowledgedTimestamp, "",
+        "", messageSkipped);
+  }
+
+  /**
+   *  create and enqueue a LoggingAuditEvent if TopicAuditConfig exists for this topic/logName,
+   *  enqueueEnabled is true and there is capacity available in the queue.
    * @param loggingAuditName
    * @param loggingAuditHeaders
    * @param messageValid
@@ -163,6 +177,25 @@ public class LoggingAuditClient {
   public void audit(String loggingAuditName, LoggingAuditHeaders loggingAuditHeaders,
                     boolean messageValid,
                     long messageAcknowledgedTimestamp, String kafkaCluster, String topic) {
+    audit(loggingAuditName, loggingAuditHeaders, messageValid, messageAcknowledgedTimestamp,
+        kafkaCluster, topic, false);
+  }
+
+
+  /**
+   *  create and enqueue a LoggingAuditEvent if TopicAuditConfig exists for this topic/logName,
+   *  enqueueEnabled is true and there is capacity available in the queue.
+   * @param loggingAuditName
+   * @param loggingAuditHeaders
+   * @param messageValid
+   * @param messageAcknowledgedTimestamp
+   * @param kafkaCluster
+   * @param topic
+   * @param messageSkipped
+   */
+  public void audit(String loggingAuditName, LoggingAuditHeaders loggingAuditHeaders,
+                    boolean messageValid, long messageAcknowledgedTimestamp, String kafkaCluster,
+                    String topic, boolean messageSkipped) {
     if (!this.auditConfigs.containsKey(loggingAuditName)) {
       OpenTsdbMetricConverter
           .incr(LoggingAuditClientMetrics.AUDIT_EVENT_WITHOUT_TOPIC_CONFIGURED_ERROR,
@@ -173,7 +206,7 @@ public class LoggingAuditClient {
     if (enqueueEnabled.get()) {
       LoggingAuditEvent loggingAuditEvent = loggingAuditEventGenerator.generateAuditEvent(
           loggingAuditName, loggingAuditHeaders, messageValid, messageAcknowledgedTimestamp,
-          kafkaCluster, topic);
+          kafkaCluster, topic, messageSkipped);
       boolean successful = false;
       try {
         // compared to put() which is blocking until available space in the queue, offer()

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditEventGenerator.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/LoggingAuditEventGenerator.java
@@ -41,7 +41,8 @@ public class LoggingAuditEventGenerator {
                                               boolean messageValid,
                                               long messageAcknowledgedTimestamp,
                                               String kafkaCluster,
-                                              String topic) {
+                                              String topic,
+                                              boolean messageSkipped) {
     return new LoggingAuditEvent().setHost(host).setStage(stage)
         .setStartAtCurrentStage(auditConfigs.get(loggingAuditName).isStartAtCurrentStage())
         .setStopAtCurrentStage(auditConfigs.get(loggingAuditName).isStopAtCurrentStage())
@@ -51,6 +52,7 @@ public class LoggingAuditEventGenerator {
         .setMessageAcknowledgedTimestamp(messageAcknowledgedTimestamp)
         .setKafkaCluster(kafkaCluster)
         .setTopic(topic)
+        .setMessageSkipped(messageSkipped)
         .setAuditEventGeneratedTimestamp(System.currentTimeMillis());
   }
 

--- a/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/common/LoggingAuditClientConfigDef.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/loggingaudit/client/common/LoggingAuditClientConfigDef.java
@@ -32,7 +32,6 @@ public class LoggingAuditClientConfigDef {
   public static final String STOP_AT_CURRENT_STAGE = "stopAtCurrentStage";
   public static final String SKIP_CORRUPTED_MESSAGE_AT_CURRENT_STAGE = "skipCorruptedMessageAtCurrentStage";
 
-
   public static final String SENDER_PREFIX = "sender.";
   public static final String SENDER_TYPE = "type";
 

--- a/singer-commons/src/main/thrift/loggingaudit.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit.thrift
@@ -57,6 +57,12 @@ struct LoggingAuditHeaders {
     *  Timstamp (millisecond) when the audit header is generated.
     */
    6: required i64 timestamp;
+
+   /**
+    *  flag indicates whether or not the current message is being tracked. Tracked message will have
+    *  audit events sent out at different stages.
+    */
+   7: optional bool tracked = false;
 }
 
 
@@ -152,6 +158,10 @@ struct LoggingAuditEvent {
     */
     11: required i64 headerGeneratedTimestamp;
 
+   /**
+    * flag indicate whether the current message is skipped at current stage as message is invalid.
+    */
+    12: optional bool messageSkipped = false;
 
 }
 

--- a/singer-commons/src/main/thrift/loggingaudit_config.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit_config.thrift
@@ -57,7 +57,7 @@ struct AuditConfig{
     */
     3: optional bool stopAtCurrentStage = false;
 
-    /**
+   /**
     *   flag indicates whether to skip corrupted messages at the current stage or not
     */
     4: optional bool skipCorruptedMessageAtCurrentStage = false;

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.36</version>
+        <version>0.8.0.37</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.36</version>
+    <version>0.8.0.37</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
1. separate injecting LoggingAuditHeaders / checksum from sending out audit events:
(1) inject LoggingAuditHeaders / checksum for every message
(2) if tracked field of LoggingAuditHeaders is set true, audit event will be sent out

2. add tracked field and skipped field to loggingaudit.thrift and support passing skipped field
when calling audit method of LoggingAuditClient

3. add enableDeserialization field and messageClass field to AuditConfig struct. it will be used later
to perform thrift deserialization if configured in order to check if a message is valid or not.