### PR TITLE
separate LoggingAuditHeaders / checksum from audit events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.37</version>
+    <version>0.8.0.38</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.37</version>
+    <version>0.8.0.38</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/loggingaudit.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit.thrift
@@ -164,4 +164,3 @@ struct LoggingAuditEvent {
     12: optional bool messageSkipped = false;
 
 }
-

--- a/singer-commons/src/main/thrift/loggingaudit_test.thrift
+++ b/singer-commons/src/main/thrift/loggingaudit_test.thrift
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace py schemas.loggingaudit
+namespace java com.pinterest.singer.loggingaudit.thrift
+include "loggingaudit.thrift"
+
+/**
+ *  AuditDemoLog1Message is used to generate thrift objects for testing.
+ **/
+struct  AuditDemoLog1Message {
+  1: required i64 timestamp;
+  2: required i64 seqId; // starts from 0
+  3: optional binary payload;
+  4: optional loggingaudit.LoggingAuditHeaders loggingAuditHeaders;
+}

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.37</version>
+        <version>0.8.0.38</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -110,13 +110,15 @@ public class SingerMetrics {
   public static final String CHECKSUM_INJECTED = "singer.audit.num_of_checksum_injected";
   public static final String AUDIT_HEADERS_METADATA_COUNT_MISMATCH = "singer.audit.headers_metadata_count_mismatch";
   public static final String AUDIT_HEADERS_METADATA_COUNT_MATCH = "singer.audit.headers_metadata_count_match";
-  public static final String NUM_CORRUPTED_MESSAGES = "singer.audit.num_corrupted_messages";
-  public static final String NUM_UNCORRUPTED_MESSAGES = "singer.audit.num_uncorrupted_messages";
-  public static final String NUM_CORRUPTED_MESSAGES_SKIPPED = "singer.audit.num_corrupted_messages_skipped";
-
+  public static final String AUDIT_NUM_INVALID_MESSAGES_SKIPPED = "singer.audit.num_invalid_messages_skipped";
+  public static final String AUDIT_NUM_CORRUPTED_MESSAGES = "singer.audit.num_corrupted_messages";
+  public static final String AUDIT_NUM_UNCORRUPTED_MESSAGES = "singer.audit.num_uncorrupted_messages";
+  public static final String AUDIT_COMPUTE_CHECKSUM_LATENCY_NANO = "singer.audit.compute_checksum_latency_nano";
 
   // Used when logging audit is enabled and is started at Singer instead of ThriftLogger.
   public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE = "singer.audit.log_message_headers_set";
   public static final String AUDIT_HEADERS_SET_FOR_LOG_MESSAGE_EXCEPTION = "singer.audit.log_message_headers_set.exception";
+  public static final String AUDIT_HEADERS_TRACKED_FOR_LOG_MESSAGE = "singer.audit.log_message_headers_tracked";
+
   public static final String SHADOW_MODE_ENABLED = "singer.shadow_mode_enabled";
 }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.37</version>
+    <version>0.8.0.38</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Earlier, in https://github.com/pinterest/singer/pull/100, LoggingAuditHeaders and
checksum fields are set for every message. Those being audited based on some
audit rate will have messageTracked field set to true in LoggingAuditHeaders,
correspondingly audit events will be sent to Kafka for audited messages.

In this PR, refactor Singer accordingly:
(1) every message now has LoggingAuditHeaders field and checksum field, in KafkaWriter.java,
use mapOfTrackedMessageMaps to record messages being tracked (messageTracked field is true in
LoggingAuditHeaders), use mapOfInvalidMessageMaps to record invalid messages due to checksum
mismatch, use mapOfOriginalIndexWithinBucket to record the original position of invalid messages
in each partition (aka bucket).

(2) message is determined as invalid if the checksum set by thrift-logger does not match the value
re-computed by Singer. If configured to skip invalid messages at Singer, original ni messages are read
and assigned to bucket i, only mi (mi <= ni) messages are sent to Kafka because there may be ni-mi messages
are invalid.

(3) audit events will be sent out for messages being tracked (messageTracked field is true) or messages
being invalid. if audited message happens to be invalid, only one audit event will be sent out.

(4) add and updated metrics to track the number of invalid message skipped, latency when performing
checksum validation, and so on.

(5) added multiple unit tests in TestKafkaWriter.java and TestCommittableKafkaWriter.java