### PR TITLE
Add sampling support to Singer Memory Efficient Processor

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -20,6 +20,8 @@ struct LogStreamProcessorConfig {
   4: optional i64 processingTimeSliceInMilliseconds = 864000000;
   // Enable memory efficient processor
   5: optional bool enableMemoryEfficientProcessor = true;
+  // Enable decider based sampling
+  6: optional bool enableDeciderBasedSampling = false;
 }
 
 enum ReaderType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -42,6 +42,7 @@ public class SingerConfigDef {
   public static final String PROCESS_TIME_SLICE_MILLIS = "processingTimeSliceInMilliseconds";
   public static final String PROCESS_TIME_SLICE_SECS = "processingTimeSliceInSeconds";
   public static final String PROCESS_ENABLE_MEMORY_EFFICIENCY = "enableMemoryEfficiency";
+  public static final String PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING = "enableDeciderBasedSampling";
   
   public static final String PRODUCER_CONFIG_PREFIX = "producerConfig.";
   public static final String SKIP_NO_LEADER_PARTITIONS = "skipNoLeaderPartitions";

--- a/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
@@ -258,7 +258,8 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
           processorConfig.getProcessingIntervalInMillisecondsMin(),
           processorConfig.getProcessingIntervalInMillisecondsMax(),
           processorConfig.getProcessingTimeSliceInMilliseconds(),
-          singerLogConfig.getLogRetentionInSeconds());
+          singerLogConfig.getLogRetentionInSeconds(),
+          processorConfig.isEnableDeciderBasedSampling());
     } else {
       return new DefaultLogStreamProcessor(
           logStream,

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -255,6 +255,17 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
     }
     return result;
   }
+  
+  int getDeciderValue() {
+    int result = 100;
+    if (logDecider != null && !logDecider.isEmpty()) {
+      Map<String, Integer> map = Decider.getInstance().getDeciderMap();
+      if (map.containsKey(logDecider)) {
+        result = map.get(logDecider);
+      }
+    }
+    return result;
+  }
 
   @Override
   public void run() {

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -1083,6 +1083,11 @@ public class LogConfigUtils {
           processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_MEMORY_EFFICIENCY));
     }
     config.setProcessingTimeSliceInMilliseconds(processingTimeSliceInMilliseconds);
+    
+    if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING)) {
+      config.setEnableDeciderBasedSampling(
+          processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING));
+    }
     return config;
   }
 


### PR DESCRIPTION
Add sampling support to Singer Memory Efficient Processor. This feature will only activate if an additional configuration is set to true, else default behavior will be preserved.

to enable this feature:
```
processor.enableDeciderBasedSampling=true
```