### PR TITLE
Add defaults for buffer size and max message size

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -86,5 +86,9 @@ public class SingerConfigDef {
   public static final String PARTITIONER_CLASS = "partitioner.class";
   public static final String REQUEST_REQUIRED_ACKS = "request.required.acks";
   public static final String PULSAR_SERVICE_URL = "pulsarServiceUrl";
+  public static final String MAX_MESSAGE_SIZE = "maxMessageSize";
+  public static final String READER_BUFFER_SIZE = "readerBufferSize";
+  public static final int DEFAULT_MAX_MESSAGE_SIZE = 100000;
+  public static final int DEFAULT_READER_BUFFER_SIZE = 10240;
   
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -950,17 +950,16 @@ public class LogConfigUtils {
   }
 
   private static ThriftReaderConfig parseThriftReaderConfig(AbstractConfiguration thriftReaderConfiguration) {
-    thriftReaderConfiguration.setThrowExceptionOnMissing(true);
-    int readerBufferSize = thriftReaderConfiguration.getInt("readerBufferSize");
-    int maxMessageSize = thriftReaderConfiguration.getInt("maxMessageSize");
+    int readerBufferSize = thriftReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
+    int maxMessageSize = thriftReaderConfiguration.getInt(SingerConfigDef.MAX_MESSAGE_SIZE, SingerConfigDef.DEFAULT_MAX_MESSAGE_SIZE);
     return new ThriftReaderConfig(readerBufferSize, maxMessageSize);
   }
 
   protected static TextReaderConfig parseTextReaderConfig(AbstractConfiguration textReaderConfiguration) throws ConfigurationException {
     textReaderConfiguration.setThrowExceptionOnMissing(true);
-    int readerBufferSize = textReaderConfiguration.getInt("readerBufferSize");
+    int readerBufferSize = textReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
     Preconditions.checkArgument(readerBufferSize > 0, "Invalid readerBufferSize");
-    int maxMessageSize = textReaderConfiguration.getInt("maxMessageSize");
+    int maxMessageSize = textReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
     Preconditions.checkArgument(maxMessageSize > 0, "Invalid maxMessageSize");
     int numMessagesPerLogMessage = textReaderConfiguration.getInt("numMessagesPerLogMessage");
     Preconditions.checkArgument(numMessagesPerLogMessage > 0, "Invalid numMessagesPerLogMessage");


### PR DESCRIPTION
Add defaults for buffer size and max message size to avoid requiring these values to be specified for every config