### PR TITLE
Add FirstByteIntPartitioner

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/writer/partitioners/FirstByteIntPartitioner.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/partitioners/FirstByteIntPartitioner.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.partitioners;
+
+import com.google.common.base.Preconditions;
+import com.pinterest.singer.writer.KafkaMessagePartitioner;
+
+import org.apache.kafka.common.PartitionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * First byte as integer partitioner for byte array key.
+ *
+ * This partitioner will:
+ * 1) return a random partition between 0 and numOfPartitions when the key is null.
+ * 2) throw runtime exception when key is not byte array type
+ * 3) read the first four bytes of the key as a byte array and compose it into an integer assuming big endian order and
+ * return the modulo of numOfPartitions on the integer.
+ */
+public class FirstByteIntPartitioner implements KafkaMessagePartitioner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(
+            FirstByteIntPartitioner.class);
+
+    private final Random random;
+
+    public FirstByteIntPartitioner() {
+        random = new Random();
+    }
+
+    public int partition(Object object, List<PartitionInfo> partitions) {
+        int numOfPartitions = partitions.size();
+        Preconditions.checkArgument(numOfPartitions > 0);
+        byte[] key = (byte[]) object;
+        if (object == null) {
+            return Math.abs(random.nextInt() % numOfPartitions);
+        } else {
+            ByteBuffer byteBuffer = ByteBuffer.wrap(key); // big-endian by default
+            int intValue = byteBuffer.getInt(); // Read the first four bytes and compose it into an integer value
+            LOG.debug("FirstByteIntPartitioner.partition producer intValue: {} on key: {}", intValue,
+                    Arrays.toString(key));
+            return intValue % numOfPartitions;
+        }
+    }
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/partitioners/TestFirstByteIntPartitioner.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/partitioners/TestFirstByteIntPartitioner.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.partitioners;
+
+import junit.framework.TestCase;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Test;
+
+public class TestFirstByteIntPartitioner extends TestCase {
+
+    private final FirstByteIntPartitioner partitioner = new FirstByteIntPartitioner();
+
+    @Test
+    public void testFirstByteIntPartitionerWithByteArray() {
+        List<PartitionInfo> partitions = Arrays.asList(new PartitionInfo[30]);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(4);
+        byteBuffer.putInt(15);
+        assertEquals(15, partitioner.partition(byteBuffer.array(), partitions));
+    }
+
+    @Test
+    public void testFirstByteIntPartitionerWithByteArrayModulo() {
+        List<PartitionInfo> partitions = Arrays.asList(new PartitionInfo[30]);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(4);
+        byteBuffer.putInt(79);
+        assertEquals(19, partitioner.partition(byteBuffer.array(), partitions));
+    }
+
+    @Test
+    public void testFirstByteIntPartitionerWithByteArrayReadFirstOnly() {
+        List<PartitionInfo> partitions = Arrays.asList(new PartitionInfo[30]);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(12);
+        byteBuffer.putInt(2).putInt(4).putInt(6);
+        assertEquals(2, partitioner.partition(byteBuffer.array(), partitions));
+    }
+
+    @Test
+    public void testFirstByteIntPartitionerWithWrongKeyType() {
+        List<PartitionInfo> partitions = Arrays.asList(new PartitionInfo[60]);
+        try {
+            partitioner.partition(new Byte[]{1, 2}, partitions);
+            fail("Should throw runtime exception on wrong key type");
+        } catch (Throwable e) {
+            assertTrue(e instanceof ClassCastException);
+        }
+    }
+
+}


### PR DESCRIPTION
Add a partitioner that allows for manually specifying a partition to write to. This is done by composing the first four bytes of the object as a byte array into an integer value and then applying the module of the number of partitions.

![Screen Shot 2021-03-04 at 9 20 39 AM](https://user-images.githubusercontent.com/194822/110003111-ec9ecc00-7cca-11eb-88e3-7a6ad6b1fe5a.png)
