### PR TITLE
Remove DNS queries from Singer that may lead to slow startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.49</version>
+    <version>0.8.0.50</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.49</version>
+    <version>0.8.0.50</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/java/com/pinterest/singer/config/Address.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/config/Address.java
@@ -1,0 +1,32 @@
+package com.pinterest.singer.config;
+
+public class Address {
+
+  private String ip;
+  private int port;
+
+  public Address() {
+  }
+
+  public Address(String ip, int port) {
+    this.ip = ip;
+    this.port = port;
+  }
+
+  public String getIp() {
+    return ip;
+  }
+
+  public void setIp(String ip) {
+    this.ip = ip;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+}

--- a/singer-commons/src/main/java/com/pinterest/singer/config/ConfigFileServerSet.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/config/ConfigFileServerSet.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.InetSocketAddress;
 
 /**
  * Implementation of the ServerSet interface that uses a file on local disk instead of talking to ZooKeeper directly.
@@ -85,7 +84,7 @@ public class ConfigFileServerSet {
           new ExceptionalFunction<byte[], Void>() {
             @Override
             public Void applyE(byte[] newContents) throws Exception {
-              ImmutableSet<InetSocketAddress> newServerSet = readServerSet(newContents);
+              ImmutableSet<Address> newServerSet = readServerSet(newContents);
               monitor.onChange(newServerSet);
               return null;
             }
@@ -96,7 +95,7 @@ public class ConfigFileServerSet {
     }
   }
 
-  protected InetSocketAddress getEndPointFromServerSetLine(String line) {
+  protected Address getEndPointFromServerSetLine(String line) {
     // We expect each line to be of the form "hostname:port". Note that host names can
     // contain ':' themselves (e.g. ipv6 addresses).
     int index = line.lastIndexOf(':');
@@ -104,11 +103,11 @@ public class ConfigFileServerSet {
 
     String host = line.substring(0, index);
     int port = Integer.parseInt(line.substring(index + 1));
-    return new InetSocketAddress(host, port);
+    return new Address(host, port);
   }
 
-  public ImmutableSet<InetSocketAddress> readServerSet(byte[] fileContent) throws IOException {
-    ImmutableSet.Builder<InetSocketAddress> builder = new ImmutableSet.Builder<>();
+  public ImmutableSet<Address> readServerSet(byte[] fileContent) throws IOException {
+    ImmutableSet.Builder<Address> builder = new ImmutableSet.Builder<>();
     InputStream stream = new ByteArrayInputStream(fileContent);
     BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
     while (true) {
@@ -121,7 +120,7 @@ public class ConfigFileServerSet {
         continue;
       }
 
-      InetSocketAddress endpoint = getEndPointFromServerSetLine(line);
+      Address endpoint = getEndPointFromServerSetLine(line);
       if (endpoint != null) {
         builder.add(endpoint);
       }

--- a/singer-commons/src/main/java/com/pinterest/singer/config/ServersetMonitor.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/config/ServersetMonitor.java
@@ -2,10 +2,8 @@ package com.pinterest.singer.config;
 
 import com.google.common.collect.ImmutableSet;
 
-import java.net.InetSocketAddress;
-
 public interface ServersetMonitor {
 
-  public void onChange(ImmutableSet<InetSocketAddress> serviceInstances);
+  public void onChange(ImmutableSet<Address> serviceInstances);
   
 }

--- a/singer-commons/src/main/java/com/pinterest/singer/utils/BrokerSetChangeListener.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/utils/BrokerSetChangeListener.java
@@ -15,6 +15,7 @@
  */
 package com.pinterest.singer.utils;
 
+import com.pinterest.singer.config.Address;
 import com.pinterest.singer.config.ServersetMonitor;
 
 import com.google.common.base.Joiner;
@@ -23,7 +24,6 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadLocalRandom;
@@ -52,10 +52,10 @@ public final class BrokerSetChangeListener implements ServersetMonitor {
   }
 
   @Override
-  public void onChange(ImmutableSet<InetSocketAddress> serviceInstances) {
+  public void onChange(ImmutableSet<Address> serviceInstances) {
     Set<String> newBrokerSet = Sets.newHashSet();
-    for (InetSocketAddress instance : serviceInstances) {
-      newBrokerSet.add(Joiner.on(":").join(instance.getHostName(), instance.getPort()));
+    for (Address instance : serviceInstances) {
+      newBrokerSet.add(Joiner.on(":").join(instance.getIp(), instance.getPort()));
     }
     // 'serverSetPath' variable will still long live. But it should be rare as we
     // only

--- a/singer-commons/src/main/java/com/pinterest/singer/utils/KafkaUtils.java
+++ b/singer-commons/src/main/java/com/pinterest/singer/utils/KafkaUtils.java
@@ -30,9 +30,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 
-import com.google.common.base.Joiner;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
-
 
 public class KafkaUtils {
 

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.49</version>
+        <version>0.8.0.50</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Pinterest, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,7 +29,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -271,7 +273,8 @@ public class TestLogConfigUtils {
     KafkaProducerConfig producerConfig = null;
     // without shadow mode activation regular serverset file should be sourced
     producerConfig = LogConfigUtils.parseProducerConfig(config);
-    assertEquals(Arrays.asList("xyz:9092"), producerConfig.getBrokerLists());
+    producerConfig = LogConfigUtils.parseProducerConfig(config);
+    assertEquals(new HashSet<>(Arrays.asList("xyz:9092")), new HashSet<>(producerConfig.getBrokerLists()));
 
     // with shadow mode override should be sourced
     LogConfigUtils.SHADOW_MODE_ENABLED = true;
@@ -279,11 +282,11 @@ public class TestLogConfigUtils {
         "discovery.test.prod");
 
     producerConfig = LogConfigUtils.parseProducerConfig(config);
-    assertEquals(Arrays.asList("test:9092"), producerConfig.getBrokerLists());
+    assertEquals(new HashSet<>(Arrays.asList("test:9092")), new HashSet<>(producerConfig.getBrokerLists()));
 
     LogConfigUtils.SHADOW_SERVERSET_MAPPING.put("/discovery/xyz/prod", "discovery.test2.prod");
     producerConfig = LogConfigUtils.parseProducerConfig(config);
-    assertEquals(Arrays.asList("test2:9092"), producerConfig.getBrokerLists());
+    assertEquals(new HashSet<>(Arrays.asList("test2:9092")), new HashSet<>(producerConfig.getBrokerLists()));
   }
 
   @Test
@@ -299,6 +302,15 @@ public class TestLogConfigUtils {
       // fail since no exception should be thrown
       throw e;
     }
+  }
+
+  @Test
+  public void testgetRandomizedStartOffsetBrokers() {
+    List<String> one = LogConfigUtils.getRandomizedStartOffsetBrokers(101,
+        new LinkedHashSet<>(Arrays.asList("1", "2", "3", "4")));
+    List<String> two = LogConfigUtils.getRandomizedStartOffsetBrokers(101,
+        new LinkedHashSet<>(Arrays.asList("1", "2", "3", "4")));
+    assertEquals(one, two);
   }
 
   @Test

--- a/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigs.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigs.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Pinterest, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,6 @@ package com.pinterest.singer.utils;
 
 import static org.junit.Assert.assertTrue;
 
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,6 +28,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 
 import com.google.common.collect.ImmutableSet;
+import com.pinterest.singer.config.Address;
 
 public class TestLogConfigs {
 
@@ -41,18 +41,18 @@ public class TestLogConfigs {
     kafkaServerSets.put("/xyz", new HashSet<>(Arrays.asList("one:9092", "two:9092", "three:9092")));
     BrokerSetChangeListener listener = new BrokerSetChangeListener("/xyz", kafkaServerSets, 100);
     listener.onChange(
-        ImmutableSet.of(new InetSocketAddress("one", 9092),
-            new InetSocketAddress("two", 9092),
-            new InetSocketAddress("three", 9092)));
+        ImmutableSet.of(new Address("one", 9092),
+            new Address("two", 9092),
+            new Address("three", 9092)));
     assertTrue(true);
     listener.onChange(
-        ImmutableSet.of(new InetSocketAddress("one", 9092),
-            new InetSocketAddress("two", 9092)));
+        ImmutableSet.of(new Address("one", 9092),
+            new Address("two", 9092)));
     assertTrue(true);
     exit.expectSystemExitWithStatus(0);
     listener.onChange(
-        ImmutableSet.of(new InetSocketAddress("one", 9092),
-            new InetSocketAddress("four", 9092)));
+        ImmutableSet.of(new Address("one", 9092),
+            new Address("four", 9092)));
   }
 
 }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.49</version>
+    <version>0.8.0.50</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Remove DNS queries from Singer that may lead to slow startup