### PR TITLE
Rule-based overrides for log configs

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -359,4 +359,10 @@ struct SingerConfig {
    */
   23: optional i32 statsPusherFrequencyInSeconds = 180;
 
+  /**
+   * Config override directory
+   */
+
+  24: optional string configOverrideDir;
+
 }

--- a/singer/src/main/java/com/pinterest/singer/config/DirectorySingerConfigurator.java
+++ b/singer/src/main/java/com/pinterest/singer/config/DirectorySingerConfigurator.java
@@ -23,9 +23,13 @@ import com.pinterest.singer.utils.LogConfigUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.twitter.ostrich.stats.Stats;
+import org.apache.commons.configuration.AbstractConfiguration;
+import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,9 +39,16 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 
 /**
@@ -77,10 +88,32 @@ public class DirectorySingerConfigurator implements SingerConfigurator {
     FileFilter fileFilter = new RegexFileFilter(CONFIG_FILE_PATTERN);
     File[] files = logConfigDir.listFiles(fileFilter);
     Arrays.sort(files);
+    List<Consumer<AbstractConfiguration>> overrideConsumers = new ArrayList<>();
+    if (singerConfig.isSetConfigOverrideDir()) {
+      File configOverrideDir = Paths.get(singerConfig.getConfigOverrideDir()).toFile();
+      if (!configOverrideDir.exists() || !configOverrideDir.isDirectory()) {
+        throw new ConfigurationException("configOverrideDir " + configOverrideDir + " is not an existing directory");
+      }
+      File[] overrideConfigs = configOverrideDir.listFiles((FilenameFilter) new SuffixFileFilter(".properties"));
+      if (overrideConfigs != null) {
+        List<File> sortedOverrideConfigs = Arrays.stream(overrideConfigs).sorted().collect(Collectors.toList());
+        for (File f : sortedOverrideConfigs) {
+          overrideConsumers.add(generateConsumerFromOverrideConfigFile(f));
+        }
+      } else {
+        LOG.info("No override configs to apply in " + configOverrideDir);
+      }
+    }
     for (File newFile : files) {
       try {
     	LOG.info("Attempting to parse log config file:" + newFile.getAbsolutePath());
-        singerConfig.addToLogConfigs(LogConfigUtils.parseLogConfigFromFile(newFile));
+        SingerLogConfig singerLogConfig;
+        if (!overrideConsumers.isEmpty()) {
+          singerLogConfig = LogConfigUtils.parseLogConfigFromFileWithOverrides(newFile, overrideConsumers);
+        } else {
+          singerLogConfig = LogConfigUtils.parseLogConfigFromFile(newFile);
+        }
+        singerConfig.addToLogConfigs(singerLogConfig);
       } catch (ConfigurationException e) {
         Stats.incr(SingerMetrics.SINGER_CONFIGURATOR_CONFIG_ERRORS);
         LOG.error("Failed to parse Singer client config file {}, exception: {}. Skip and continue.",
@@ -145,5 +178,21 @@ public class DirectorySingerConfigurator implements SingerConfigurator {
     }
 
     return config.toString();
+  }
+
+  private static Consumer<AbstractConfiguration> generateConsumerFromOverrideConfigFile(File file) throws ConfigurationException {
+    PropertiesConfiguration overrideConfig = new PropertiesConfiguration(file);
+    String matchConfigName = overrideConfig.getString("match.config.name");
+    String matchConfigValue = overrideConfig.getString("match.config.value");
+    Configuration override = overrideConfig.subset("override");
+    return conf -> {
+      if (conf.containsKey(matchConfigName) && conf.getProperty(matchConfigName).toString().equals(matchConfigValue)) {
+        Iterator<String> itr = override.getKeys();
+        while (itr.hasNext()) {
+          String key = itr.next();
+          conf.setProperty(key, override.getProperty(key));
+        }
+      }
+    };
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -91,6 +91,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.Iterator;
@@ -434,6 +435,14 @@ public class LogConfigUtils {
     return parseLogConfig(parseLogNamespace(logConfigFile), logConfig);
   }
 
+  public static SingerLogConfig parseLogConfigFromFileWithOverrides(File logConfigFile, List<Consumer<AbstractConfiguration>> overrides) throws ConfigurationException {
+    AbstractConfiguration logConfig = new PropertiesConfiguration(logConfigFile);
+    for (Consumer<AbstractConfiguration> consumer : overrides) {
+      consumer.accept(logConfig);
+    }
+    return parseLogConfig(parseLogNamespace(logConfigFile), logConfig);
+  }
+
   public static SingerLogConfig[] parseLogStreamConfigFromFile(String logConfigFile) throws ConfigurationException {
     PropertiesConfiguration logConfig = new PropertiesConfiguration();
     logConfig.setDelimiterParsingDisabled(true);
@@ -644,6 +653,9 @@ public class LogConfigUtils {
           throw new ConfigurationException("Error reading shadow mapping file", e);
         }
       }
+    }
+    if (singerConfiguration.containsKey(("configOverrideDir"))) {
+      singerConfig.setConfigOverrideDir(singerConfiguration.getString("configOverrideDir"));
     }
     return singerConfig;
   }


### PR DESCRIPTION
Add capability of doing rule-based (currently only exact match) override of log configs
Can be done by setting `configOverrideDir` in `singer.properties` and have property files in that directory with `match.config.name` set to the config name to be matched, and `match.config.value` to the config value; add `override.` prefix to the configs that need to be overriden. Files will be sorted in alphabetical order and later overrides will have higher precedence over earlier ones.

Example:
In the `singer.properties` file:
```
...
singer.configOverrideDir=/path/to/override/dir
...
```

In `path/to/override/dir/100-override-kafka-buffer-memory.properties`
```
match.config.name=writer.type
match.config.value=kafka

override.writer.kafka.producerConfig.buffer.memory=100000
```

in `path/to/override/dir/101-override-kafka08-buffer-memory.properties`
```
match.config.name=writer.type
match.config.value=kafka08

override.writer.kafka08.producerConfig.buffer.memory=100000
```

This setup will match all the log configs with `writer.type=kafka` or `writer.type=kafka08` and override the `writer.kafka.producerConfig.buffer.memory` config to 100000 for all of the matching property files.