### PR TITLE
Fix excessive creation of KafkaProducerMetricsMonitor threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.53</version>
+    <version>0.8.0.54</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.53</version>
+    <version>0.8.0.54</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.53</version>
+        <version>0.8.0.54</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
@@ -163,16 +163,16 @@ public final class SingerSettings {
 
           logWritingExecutors.put(clusterSig, threadPool);
         }
-        
-        kafkaProducerMonitorThread = new Thread(new KafkaProducerMetricsMonitor());
-        kafkaProducerMonitorThread.setDaemon(true);
-        kafkaProducerMonitorThread.start();
 
         if (loggingAuditClient != null && logConfig.isEnableLoggingAudit() &&
             logConfig.getAuditConfig() != null){
           loggingAuditClient.addAuditConfig(logConfig.getName(), logConfig.getAuditConfig());
         }
       }
+
+      kafkaProducerMonitorThread = new Thread(new KafkaProducerMetricsMonitor());
+      kafkaProducerMonitorThread.setDaemon(true);
+      kafkaProducerMonitorThread.start();
     }
 
     if (singerConfig != null

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.53</version>
+    <version>0.8.0.54</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Previously, a KafkaProducerMetricsMonitor thread was created for each log config, which causes a lot of threads to be created and wasting stack memory.