### PR TITLE
Refactor CommittableKafkaWriter to use non-blocking request handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.54</version>
+    <version>0.8.0.55</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.54</version>
+    <version>0.8.0.55</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.54</version>
+        <version>0.8.0.55</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/kafka/CommittableKafkaWriter.java
@@ -17,15 +17,21 @@ package com.pinterest.singer.writer.kafka;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -51,7 +57,6 @@ import com.pinterest.singer.thrift.configuration.SingerRestartConfig;
 import com.pinterest.singer.writer.KafkaMessagePartitioner;
 import com.pinterest.singer.writer.KafkaProducerManager;
 import com.pinterest.singer.writer.KafkaWriter;
-import com.pinterest.singer.writer.KafkaWritingTaskResult;
 
 /**
  * Committable writer that implements the commit design pattern methods of {@link LogStreamWriter}
@@ -67,8 +72,15 @@ public class CommittableKafkaWriter extends KafkaWriter {
   private Map<Integer, Map<Integer, LoggingAuditHeaders>> committableMapOfTrackedMessageMaps;
   private Map<Integer, Map<Integer, LoggingAuditHeaders>> committableMapOfInvalidMessageMaps;
   private Map<Integer, Integer> committableMapOfOriginalIndexWithinBucket;
-  private Map<Integer, KafkaWritingTaskFuture> commitableBuckets;
+  private Map<Integer, KafkaWritingTaskFuture> committableBuckets;
   private KafkaProducer<byte[], byte[]> committableProducer;
+  private static final ScheduledExecutorService executionTimer;
+  static {
+    ScheduledThreadPoolExecutor tmpTimer = new ScheduledThreadPoolExecutor(1);
+    tmpTimer.setRemoveOnCancelPolicy(true);
+    executionTimer = tmpTimer;
+  }
+
 
   protected CommittableKafkaWriter(KafkaProducerConfig producerConfig,
                                    KafkaMessagePartitioner partitioner,
@@ -123,8 +135,6 @@ public class CommittableKafkaWriter extends KafkaWriter {
       committableProducer.beginTransaction();
     }
     List<PartitionInfo> partitions = committableProducer.partitionsFor(topic);
-    List<PartitionInfo> committableSortedPartitions = new ArrayList<>(partitions);
-    Collections.sort(committableSortedPartitions, COMPARATOR);
 
     committableValidPartitions = partitions;
     if (skipNoLeaderPartitions) {
@@ -138,20 +148,18 @@ public class CommittableKafkaWriter extends KafkaWriter {
       }
     }
 
-    commitableBuckets = new HashMap<>();
+    committableBuckets = new HashMap<>();
     committableMapOfTrackedMessageMaps = new HashMap<>();
     committableMapOfInvalidMessageMaps = new HashMap<>();
     committableMapOfOriginalIndexWithinBucket = new HashMap<>();
 
-
-    for (int i = 0; i < committableValidPartitions.size(); i++) {
+    for (PartitionInfo partitionInfo : committableValidPartitions) {
       // for each partitionId, there is a corresponding bucket in buckets and a
       // corresponding headersMap in mapOfHeadersMaps.
-      PartitionInfo partitionInfo = committableValidPartitions.get(i);
       int partitionId = partitionInfo.partition();
-      commitableBuckets.put(partitionId, new KafkaWritingTaskFuture(partitionInfo));
-      committableMapOfTrackedMessageMaps.put(partitionId, new HashMap<Integer, LoggingAuditHeaders>());
-      committableMapOfInvalidMessageMaps.put(partitionId, new HashMap<Integer, LoggingAuditHeaders>());
+      committableBuckets.put(partitionId, new KafkaWritingTaskFuture(partitionInfo));
+      committableMapOfTrackedMessageMaps.put(partitionId, new HashMap<>());
+      committableMapOfInvalidMessageMaps.put(partitionId, new HashMap<>());
       committableMapOfOriginalIndexWithinBucket.put(partitionId, -1);
     }
   }
@@ -181,18 +189,25 @@ public class CommittableKafkaWriter extends KafkaWriter {
       }
     }
 
-    KafkaWritingTaskFuture kafkaWritingTaskFutureResult = commitableBuckets.get(partitionId);
-    List<Future<RecordMetadata>> recordMetadataList = kafkaWritingTaskFutureResult
+    KafkaWritingTaskFuture kafkaWritingTaskFutureResult = committableBuckets.get(partitionId);
+    List<CompletableFuture<RecordMetadata>> recordMetadataList = kafkaWritingTaskFutureResult
         .getRecordMetadataList();
 
     if (recordMetadataList.isEmpty()) {
       kafkaWritingTaskFutureResult.setFirstProduceTimestamp(System.currentTimeMillis());
     }
 
-    Future<RecordMetadata> send = committableProducer.send(keyedMessage);
-    recordMetadataList.add(send);
+    CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
+    committableProducer.send(keyedMessage, (recordMetadata, exception) -> {
+      if (exception != null) {
+        future.completeExceptionally(exception);
+      } else {
+        future.complete(recordMetadata);
+      }
+    });
+    recordMetadataList.add(future);
   }
-  
+
   public void addStandardHeaders(LogMessageAndPosition message, Headers headers) {
     headers.add(MESSAGE_ID,
         ByteBuffer.wrap(new byte[SINGER_DEFAULT_MESSAGEID_LENGTH])
@@ -211,70 +226,131 @@ public class CommittableKafkaWriter extends KafkaWriter {
   @Override
   public void endCommit(int numLogMessages) throws LogStreamWriterException {
     committableProducer.flush();
-    List<Future<KafkaWritingTaskResult>> resultFutures = new ArrayList<>();
-    for (Entry<Integer, KafkaWritingTaskFuture> entry : commitableBuckets.entrySet()) {
-      Future<KafkaWritingTaskResult> future = clusterThreadPool.submit(new KafkaWriteTask(entry));
-      resultFutures.add(future);
+
+    List<CompletableFuture<Integer>> bucketFutures = new ArrayList<>();
+    for(KafkaWritingTaskFuture f : committableBuckets.values()) {
+      List<CompletableFuture<RecordMetadata>> futureList = f.getRecordMetadataList();
+      if (futureList.isEmpty()) {
+        continue;
+      }
+      long start = f.getFirstProduceTimestamp();
+      int leaderNode = f.getPartitionInfo().leader().id();
+      int size = futureList.size();
+      OpenTsdbMetricConverter.addMetric(SingerMetrics.WRITER_BATCH_SIZE, size, "topic=" + topic,
+          "host=" + KafkaWriter.HOSTNAME);
+
+      // resolves with the latency of that bucket
+      CompletableFuture<Integer> bucketFuture = CompletableFuture.allOf(futureList.toArray(new CompletableFuture[0]))
+          .handleAsync((v, t) -> {
+            if (t != null) {
+              handleBucketException(leaderNode, size, t);
+              if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+              } else {
+                throw new RuntimeException(t);
+              }
+            }
+            int kafkaLatency = (int) (System.currentTimeMillis() - start);
+            // we shouldn't have latency greater than 2B milliseconds so it should be okay
+            // to downcast to integer
+            OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_SUCCESS, 1,
+                "broker=" + leaderNode);
+            OpenTsdbMetricConverter.addGranularMetric(SingerMetrics.BROKER_WRITE_LATENCY,
+                kafkaLatency, "broker=" + leaderNode);
+            return kafkaLatency;
+          });
+      bucketFutures.add(bucketFuture);
     }
+    CompletableFuture<Void> batchFuture = CompletableFuture.allOf(bucketFutures.toArray(new CompletableFuture[0]));
 
-    int bytesWritten = 0;
-    int maxKafkaBatchWriteLatency = 0;
-    boolean anyBucketSendFailed = false;
+    // Set a timeout task that will cause the batch future to fail after writeTimeoutInSeconds
+    CompletableFuture<Void> timerFuture = new CompletableFuture<>();
+    Future<?> timerTask = executionTimer.schedule(() -> {
+      timerFuture.completeExceptionally(new TimeoutException("Kafka batch write timed out after " + writeTimeoutInSeconds + " seconds"));
+    }, writeTimeoutInSeconds, TimeUnit.SECONDS);
+
+    CompletableFuture<Void> writerFuture = batchFuture
+        .applyToEitherAsync(timerFuture, Function.identity())
+        .whenComplete(
+            (v, t) -> {
+              if (t != null) {
+                handleBatchException(numLogMessages, t);
+              } else {
+                timerTask.cancel(true);
+                onBatchComplete(numLogMessages, bucketFutures);
+              }
+            }
+        );
     try {
-      for (Future<KafkaWritingTaskResult> f : resultFutures) {
-        KafkaWritingTaskResult result = f.get();
-        if (!result.success) {
-          LOG.error("Failed to write messages to kafka topic {}", topic, result.exception);
-          anyBucketSendFailed = true;
-        } else {
-          bytesWritten += result.getWrittenBytesSize();
-          // get the max write latency
-          maxKafkaBatchWriteLatency = Math.max(maxKafkaBatchWriteLatency,
-              result.getKafkaBatchWriteLatencyInMillis());
-          if (isLoggingAuditEnabledAndConfigured()) {
-            captureAndLogAuditEvents(result);
-          }
-        }
-      }
-      if (anyBucketSendFailed) {
-        throw new LogStreamWriterException("Failed to write messages to kafka");
-      }
-
-      if (producerConfig.isTransactionEnabled()) {
-        committableProducer.commitTransaction();
-        OpenTsdbMetricConverter.incr(SingerMetrics.NUM_COMMITED_TRANSACTIONS, 1, "topic=" + topic,
-            "host=" + HOSTNAME, "logname=" + logName);
-      }
-      updateWriteSuccessMetrics(numLogMessages, bytesWritten, maxKafkaBatchWriteLatency);
-    } catch (Exception e) {
-      LOG.error("Caught exception when write " + numLogMessages + " messages to producer.", e);
-
-      SingerRestartConfig restartConfig = SingerSettings.getSingerConfig().singerRestartConfig;
-      if (restartConfig != null && restartConfig.restartOnFailures
-          && failureCounter.incrementAndGet() > restartConfig.numOfFailuesAllowed) {
-        LOG.error("Encountered {} kafka logging failures.", failureCounter.get());
-      }
-      if (producerConfig.isTransactionEnabled()) {
-        committableProducer.abortTransaction();
-        OpenTsdbMetricConverter.incr(SingerMetrics.NUM_ABORTED_TRANSACTIONS, 1, "topic=" + topic,
-            "host=" + HOSTNAME, "logname=" + logName);
-      }
-      KafkaProducerManager.resetProducer(producerConfig);
-      updateWriteFailureMetrics(numLogMessages);
+      writerFuture.get();
+    } catch (CompletionException | InterruptedException | ExecutionException e) {
       throw new LogStreamWriterException("Failed to write messages to topic " + topic, e);
-    } finally {
-      for (Future<KafkaWritingTaskResult> f : resultFutures) {
-        if (!f.isDone() && !f.isCancelled()) {
-          f.cancel(true);
-        }
-      }
     }
   }
 
-  private void captureAndLogAuditEvents(KafkaWritingTaskResult result) {
+  private void handleBucketException(int leaderNode, int size, Throwable t) {
+    if (t instanceof org.apache.kafka.common.errors.RecordTooLargeException) {
+      LOG.error("Kafka write failure due to excessively large message size", t);
+      OpenTsdbMetricConverter.incr(SingerMetrics.OVERSIZED_MESSAGES, 1, "topic=" + topic,
+          "host=" + KafkaWriter.HOSTNAME);
+    } else if (t instanceof org.apache.kafka.common.errors.SslAuthenticationException) {
+      LOG.error("Kafka write failure due to SSL authentication failure", t);
+      OpenTsdbMetricConverter.incr(SingerMetrics.WRITER_SSL_EXCEPTION, 1, "topic=" + topic,
+          "host=" + KafkaWriter.HOSTNAME);
+    } else if (t instanceof Exception) {
+      LOG.error("Failed to write " + size + " messages to kafka", t);
+      OpenTsdbMetricConverter.incr(SingerMetrics.WRITE_FAILURE, 1, "topic=" + topic,
+          "host=" + KafkaWriter.HOSTNAME);
+      OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_FAILURE, 1,
+          "broker=" + leaderNode);
+    }
+  }
+
+  private void onBatchComplete(int numLogMessages, List<CompletableFuture<Integer>> bucketFutures) {
+    int bytesWritten = 0;
+    for (Entry<Integer, KafkaWritingTaskFuture> entry : committableBuckets.entrySet()) {
+      List<CompletableFuture<RecordMetadata>> futureList = entry.getValue().getRecordMetadataList();
+      if (futureList.isEmpty()) {
+        continue;
+      }
+      List<RecordMetadata> recordMetadataList = futureList.stream()
+          .map(CompletableFuture::join)
+          .collect(Collectors.toList());
+      if (isLoggingAuditEnabledAndConfigured()) {
+        captureAndLogAuditEvents(entry.getKey(), recordMetadataList);
+      }
+      bytesWritten += recordMetadataList.stream().mapToInt(rmd -> rmd.serializedKeySize() + rmd.serializedValueSize()).sum();
+    }
+    int maxKafkaBatchWriteLatency = bucketFutures.stream().mapToInt(CompletableFuture::join).max().orElse(0);
+    if (producerConfig.isTransactionEnabled()) {
+      committableProducer.commitTransaction();
+      OpenTsdbMetricConverter.incr(SingerMetrics.NUM_COMMITED_TRANSACTIONS, 1, "topic=" + topic,
+          "host=" + HOSTNAME, "logname=" + logName);
+    }
+    updateWriteSuccessMetrics(numLogMessages, bytesWritten, maxKafkaBatchWriteLatency);
+  }
+
+  private void handleBatchException(int numLogMessages, Throwable t) {
+    LOG.error("Caught exception when write " + numLogMessages + " messages to producer.", t);
+
+    SingerRestartConfig restartConfig = SingerSettings.getSingerConfig().singerRestartConfig;
+    if (restartConfig != null && restartConfig.restartOnFailures
+        && failureCounter.incrementAndGet() > restartConfig.numOfFailuesAllowed) {
+      LOG.error("Encountered {} kafka logging failures.", failureCounter.get());
+    }
+    if (producerConfig.isTransactionEnabled()) {
+      committableProducer.abortTransaction();
+      OpenTsdbMetricConverter.incr(SingerMetrics.NUM_ABORTED_TRANSACTIONS, 1, "topic=" + topic,
+          "host=" + HOSTNAME, "logname=" + logName);
+    }
+    KafkaProducerManager.resetProducer(producerConfig);
+    updateWriteFailureMetrics(numLogMessages);
+    throw new CompletionException("Failed to write messages to topic " + topic, t);
+  }
+
+  private void captureAndLogAuditEvents(int bucketIndex, List<RecordMetadata> recordMetadataList) {
     if (isLoggingAuditEnabledAndConfigured()) {
-      int bucketIndex = result.getPartition();
-      enqueueLoggingAuditEvents(result, committableMapOfTrackedMessageMaps.get(bucketIndex),
+      enqueueLoggingAuditEvents(recordMetadataList, committableMapOfTrackedMessageMaps.get(bucketIndex),
           committableMapOfInvalidMessageMaps.get(bucketIndex));
     }
   }
@@ -284,7 +360,7 @@ public class CommittableKafkaWriter extends KafkaWriter {
         "host=" + HOSTNAME);
     OpenTsdbMetricConverter.incr("singer.writer.num_kafka_messages_delivery_failure",
         numLogMessages, "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
-    OpenTsdbMetricConverter.incr(SingerMetrics.SINGER_WRITER 
+    OpenTsdbMetricConverter.incr(SingerMetrics.SINGER_WRITER
         + "num_committable_kafka_messages_delivery_failure", numLogMessages,
         "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
   }
@@ -296,7 +372,7 @@ public class CommittableKafkaWriter extends KafkaWriter {
         "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
     OpenTsdbMetricConverter.incr(SingerMetrics.NUM_KAFKA_MESSAGES, numLogMessages,
         "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
-    OpenTsdbMetricConverter.incr(SingerMetrics.SINGER_WRITER 
+    OpenTsdbMetricConverter.incr(SingerMetrics.SINGER_WRITER
         + "num_committable_kafka_messages_delivery_success", numLogMessages,
         "topic=" + topic, "host=" + HOSTNAME, "logname=" + logName);
   }
@@ -306,90 +382,9 @@ public class CommittableKafkaWriter extends KafkaWriter {
     return true;
   }
 
-  protected final class KafkaWriteTask implements Callable<KafkaWritingTaskResult> {
-    private final Entry<Integer, KafkaWritingTaskFuture> entry;
-
-    protected KafkaWriteTask(Entry<Integer, KafkaWritingTaskFuture> entry) {
-      this.entry = entry;
-    }
-
-    @Override
-    public KafkaWritingTaskResult call() throws LogStreamWriterException {
-      KafkaWritingTaskResult result = null;
-      KafkaWritingTaskFuture task = entry.getValue();
-      int size = task.getRecordMetadataList().size();
-      PartitionInfo partitionInfo = task.getPartitionInfo();
-      int leaderNode = partitionInfo.leader().id();
-      if (size > 0) {
-        OpenTsdbMetricConverter.addMetric(SingerMetrics.WRITER_BATCH_SIZE, size, "topic=" + topic,
-            "host=" + KafkaWriter.HOSTNAME);
-      }
-      try {
-        List<RecordMetadata> recordMetadataList = new ArrayList<>();
-        int bytesWritten = 0;
-        for (Future<RecordMetadata> future : task.getRecordMetadataList()) {
-          if (future.isCancelled()) {
-            result = new KafkaWritingTaskResult(false, 0, 0);
-            break;
-          } else {
-            // We will get TimeoutException if the wait timed out
-            RecordMetadata recordMetadata = future.get(writeTimeoutInSeconds, TimeUnit.SECONDS);
-
-            // used for tracking metrics
-            if (recordMetadata != null) {
-              bytesWritten += recordMetadata.serializedKeySize()
-                  + recordMetadata.serializedValueSize();
-              recordMetadataList.add(recordMetadata);
-            }
-          }
-        }
-        if (result == null) {
-          // we can down convert since latency should be less that Integer.MAX_VALUE
-          int kafkaLatency = (int) (System.currentTimeMillis() - task.getFirstProduceTimestamp());
-          // we shouldn't have latency creater than 2B milliseoncds so it should be okay
-          // to downcast to integer
-          result = new KafkaWritingTaskResult(true, bytesWritten, (int) kafkaLatency);
-          result.setRecordMetadataList(recordMetadataList);
-          result.setPartition(partitionInfo.partition());
-          OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_SUCCESS, 1,
-              "broker=" + leaderNode);
-          OpenTsdbMetricConverter.addGranularMetric(SingerMetrics.BROKER_WRITE_LATENCY,
-              kafkaLatency, "broker=" + leaderNode);
-        }
-      } catch (org.apache.kafka.common.errors.RecordTooLargeException e) {
-        LOG.error("Kafka write failure due to excessively large message size", e);
-        OpenTsdbMetricConverter.incr(SingerMetrics.OVERSIZED_MESSAGES, 1, "topic=" + topic,
-            "host=" + KafkaWriter.HOSTNAME);
-        result = new KafkaWritingTaskResult(false, e);
-      } catch (org.apache.kafka.common.errors.SslAuthenticationException e) {
-        LOG.error("Kafka write failure due to SSL authentication failure", e);
-        OpenTsdbMetricConverter.incr(SingerMetrics.WRITER_SSL_EXCEPTION, 1, "topic=" + topic,
-            "host=" + KafkaWriter.HOSTNAME);
-        result = new KafkaWritingTaskResult(false, e);
-      } catch (Exception e) {
-        String errorMsg = "Failed to write " + size + " messages to kafka";
-        LOG.error(errorMsg, e);
-        OpenTsdbMetricConverter.incr(SingerMetrics.WRITE_FAILURE, 1, "topic=" + topic,
-            "host=" + KafkaWriter.HOSTNAME);
-        OpenTsdbMetricConverter.incrGranular(SingerMetrics.BROKER_WRITE_FAILURE, 1,
-            "broker=" + leaderNode);
-        result = new KafkaWritingTaskResult(false, e);
-      } finally {
-        if (result != null && !result.success) {
-          for (Future<RecordMetadata> future : task.getRecordMetadataList()) {
-            if (!future.isCancelled() && !future.isDone()) {
-              future.cancel(true);
-            }
-          }
-        }
-      }
-      return result;
-    }
-  }
-
   @VisibleForTesting
-  protected Map<Integer, KafkaWritingTaskFuture> getCommitableBuckets() {
-    return commitableBuckets;
+  protected Map<Integer, KafkaWritingTaskFuture> getCommittableBuckets() {
+    return committableBuckets;
   }
 
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/kafka/KafkaWritingTaskFuture.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/kafka/KafkaWritingTaskFuture.java
@@ -20,8 +20,7 @@ import org.apache.kafka.common.PartitionInfo;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
-
+import java.util.concurrent.CompletableFuture;
 /**
  * Write Task Future created for tracking partition batch write status when
  * using {@link CommittableKafkaWriter}
@@ -29,74 +28,25 @@ import java.util.concurrent.Future;
 public class KafkaWritingTaskFuture {
 
   private long firstProduceTimestamp;
-  public boolean success;
-  public Exception exception;
-  private int writtenBytesSize;
-  private int kafkaBatchWriteLatencyInMillis;
   /**
    * a list of the RecordMetadata for every producer record in a KafkaWritingTask.
    * Initialization is needed to prevent NullPointerException when
    * KafkaWritingTask fails.
    */
-  private List<Future<RecordMetadata>> recordMetadataList = new ArrayList<>();
+  private List<CompletableFuture<RecordMetadata>> recordMetadataList = new ArrayList<>();
   private PartitionInfo partitionInfo;
 
   public KafkaWritingTaskFuture(PartitionInfo partitionInfo) {
     this.partitionInfo = partitionInfo;
   }
 
-  public KafkaWritingTaskFuture(boolean successFlag, int bytes, int kafkaLatency) {
-    this.success = successFlag;
-    this.writtenBytesSize = bytes;
-    this.kafkaBatchWriteLatencyInMillis = kafkaLatency;
-    this.exception = null;
-  }
-
-  public KafkaWritingTaskFuture(boolean successFlag, Exception e) {
-    this.success = successFlag;
-    this.exception = e;
-  }
-
-  public int getWrittenBytesSize() {
-    return writtenBytesSize;
-  }
-
-  public int getKafkaBatchWriteLatencyInMillis() {
-    return kafkaBatchWriteLatencyInMillis;
-  }
-
-  public List<Future<RecordMetadata>> getRecordMetadataList() {
+  public List<CompletableFuture<RecordMetadata>> getRecordMetadataList() {
     return recordMetadataList;
   }
 
-  public void setRecordMetadataList(List<Future<RecordMetadata>> recordMetadataList) {
+  public void setRecordMetadataList(List<CompletableFuture<RecordMetadata>> recordMetadataList) {
     this.recordMetadataList = recordMetadataList;
   }
-
-  public boolean isSuccess() {
-    return success;
-  }
-
-  public void setSuccess(boolean success) {
-    this.success = success;
-  }
-
-  public Exception getException() {
-    return exception;
-  }
-
-  public void setException(Exception exception) {
-    this.exception = exception;
-  }
-
-  public void setWrittenBytesSize(int writtenBytesSize) {
-    this.writtenBytesSize = writtenBytesSize;
-  }
-
-  public void setKafkaBatchWriteLatencyInMillis(int kafkaBatchWriteLatencyInMillis) {
-    this.kafkaBatchWriteLatencyInMillis = kafkaBatchWriteLatencyInMillis;
-  }
-
   public long getFirstProduceTimestamp() {
     return firstProduceTimestamp;
   }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.54</version>
+    <version>0.8.0.55</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
tl; dr: Replaced `clusterThreadPool` usage by using CompletableFutures to implement non-blocking kafka request handling

In this diff, we remove the usage of clusterThreadPool in `CommitableKafkaWriter`. Previously, the `clusterThreadPool` was allocated per cluster and used for tracking metrics of the `Future<RecordMetadata>`. This caused a lot of threads to be used if Singer is publishing to a lot of clusters. Since these threads are used only for tracking, we found out that they could be eliminated and instead refactored into `CompletableFuture`s that can be executed asynchronously with the shared common `ForkJoinPool` as long as they remain non-blocking. 
We also leverage the callback in `send` to achieve this:
```
    CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
    committableProducer.send(keyedMessage, (recordMetadata, exception) -> {
      if (exception != null) {
        future.completeExceptionally(exception);
      } else {
        future.complete(recordMetadata);
      }
    });
```
 After this diff, it is expected to drop the number of threads created by Singer and significantly reduce the native memory allocated for multi-cluster-publishing Singer instances.