### PR TITLE
Remove internal package from open source project

### DIFF
--- a/thrift-logger-python/requirements.txt
+++ b/thrift-logger-python/requirements.txt
@@ -1,5 +1,4 @@
 mock==1.0.1
 nose-pathmunge==0.1.2
 nose==1.3.4
-pinstatsd==1.0.55
 thrift==0.8.0

--- a/thrift-logger-python/setup.py
+++ b/thrift-logger-python/setup.py
@@ -9,7 +9,6 @@ setup(
     author='Pinterest, inc.',
     url='http://www.pinterest.com',
     install_requires=[
-        'pinstatsd==1.0.55',
         'thrift==0.8.0'
     ],
     packages=['thrift_logger', 'thrift_logger/thrift_libs'])


### PR DESCRIPTION
This library is not available in pypi so should not be treated as a requirement for the open source project.