### PR TITLE
Header injection from environment variables for ThriftLogFileReader

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -32,6 +32,8 @@ enum ReaderType {
 struct ThriftReaderConfig {
   1: required i32 readerBufferSize;
   2: required i32 maxMessageSize;
+  // custom environment variables to be injected into thrift logs
+  3:optional map<string, binary> environmentVariables;
 }
 
 enum TextLogMessageType {

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReaderFactory.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.FileSystems;
+import java.util.HashMap;
 
 /**
  * Factory class that create ThriftLogFileReader instances based on ThriftReaderConfig.
@@ -54,8 +55,15 @@ public class ThriftLogFileReaderFactory implements LogFileReaderFactory {
         logStream.initialize();
         path = logStream.getLogFilePath(logFile);
       }
-      reader = new ThriftLogFileReader(logFile, path, byteOffset,
-          readerConfig.getReaderBufferSize(), readerConfig.getMaxMessageSize());
+      reader = new ThriftLogFileReader(
+          logFile,
+          path,
+          byteOffset,
+          readerConfig.getReaderBufferSize(),
+          readerConfig.getMaxMessageSize(),
+          readerConfig.isSetEnvironmentVariables() ?
+          new HashMap<>(readerConfig.getEnvironmentVariables()) : null
+      );
     } catch (LogFileReaderException e) {
       LOG.warn("Exception in getLogFileReader", e);
       long inode = logFile.getInode();

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -992,7 +992,20 @@ public class LogConfigUtils {
   private static ThriftReaderConfig parseThriftReaderConfig(AbstractConfiguration thriftReaderConfiguration) {
     int readerBufferSize = thriftReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
     int maxMessageSize = thriftReaderConfiguration.getInt(SingerConfigDef.MAX_MESSAGE_SIZE, SingerConfigDef.DEFAULT_MAX_MESSAGE_SIZE);
-    return new ThriftReaderConfig(readerBufferSize, maxMessageSize);
+    ThriftReaderConfig config = new ThriftReaderConfig(readerBufferSize, maxMessageSize);
+    if (thriftReaderConfiguration.containsKey("prependEnvironmentVariables")) {
+      String str = thriftReaderConfiguration.getString("prependEnvironmentVariables");
+      String[] variables = str.split("\\|");
+      Map<String, ByteBuffer> headers = new HashMap<>();
+      for (String variable : variables) {
+        String env = System.getenv(variable);
+        if (env != null) {
+          headers.put(variable, ByteBuffer.wrap(env.getBytes()));
+        }
+      }
+      config.setEnvironmentVariables(headers);
+    }
+    return config;
   }
 
   protected static TextReaderConfig parseTextReaderConfig(AbstractConfiguration textReaderConfiguration) throws ConfigurationException {


### PR DESCRIPTION
Porting same feature inTextLogFileReader which allows Singer to inject headers to the messages based on config-specified environment variables.