### PR TITLE
Add instance level sampling

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -9,6 +9,12 @@ struct LogMonitorConfig {
   1: required i32 monitorIntervalInSecs;
 }
 
+enum SamplingType {
+    NONE = 0,
+    MESSAGE = 1,
+    INSTANCE = 2
+}
+
 struct LogStreamProcessorConfig {
   // Minimum processing interval.
   1: required i64 processingIntervalInMillisecondsMin;
@@ -20,8 +26,10 @@ struct LogStreamProcessorConfig {
   4: optional i64 processingTimeSliceInMilliseconds = 864000000;
   // Enable memory efficient processor
   5: optional bool enableMemoryEfficientProcessor = true;
-  // Enable decider based sampling
+  // (DEPRECATED) Enable decider based sampling
   6: optional bool enableDeciderBasedSampling = false;
+  // Sampling type
+  7: optional SamplingType deciderBasedSampling = 0;
 }
 
 enum ReaderType {
@@ -33,7 +41,7 @@ struct ThriftReaderConfig {
   1: required i32 readerBufferSize;
   2: required i32 maxMessageSize;
   // custom environment variables to be injected into thrift logs
-  3:optional map<string, binary> environmentVariables;
+  3: optional map<string, binary> environmentVariables;
 }
 
 enum TextLogMessageType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -43,6 +43,7 @@ public class SingerConfigDef {
   public static final String PROCESS_TIME_SLICE_SECS = "processingTimeSliceInSeconds";
   public static final String PROCESS_ENABLE_MEMORY_EFFICIENCY = "enableMemoryEfficiency";
   public static final String PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING = "enableDeciderBasedSampling";
+  public static final String PROCESS_DECIDER_BASED_SAMPLING = "deciderBasedSampling";
   
   public static final String PRODUCER_CONFIG_PREFIX = "producerConfig.";
   public static final String SKIP_NO_LEADER_PARTITIONS = "skipNoLeaderPartitions";
@@ -90,5 +91,6 @@ public class SingerConfigDef {
   public static final String READER_BUFFER_SIZE = "readerBufferSize";
   public static final int DEFAULT_MAX_MESSAGE_SIZE = 100000;
   public static final int DEFAULT_READER_BUFFER_SIZE = 10240;
-  
+
+  public static final String PROCESS_BATCH_SIZE = "batchSize";
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -42,6 +42,7 @@ import com.pinterest.singer.thrift.configuration.PulsarWriterConfig;
 import com.pinterest.singer.thrift.configuration.ReaderType;
 import com.pinterest.singer.thrift.configuration.RealpinObjectType;
 import com.pinterest.singer.thrift.configuration.RealpinWriterConfig;
+import com.pinterest.singer.thrift.configuration.SamplingType;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
 import com.pinterest.singer.thrift.configuration.SingerRestartConfig;
@@ -1092,7 +1093,7 @@ public class LogConfigUtils {
     return config;
   }
 
-  private static LogStreamProcessorConfig parseLogStreamProcessorConfig(AbstractConfiguration processorConfiguration) {
+  protected static LogStreamProcessorConfig parseLogStreamProcessorConfig(AbstractConfiguration processorConfiguration) {
     processorConfiguration.setThrowExceptionOnMissing(true);
     long minIntervalInMillis;
     if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_INTERVAL_MILLIS)) {
@@ -1102,7 +1103,7 @@ public class LogConfigUtils {
           * 1000L;
     }
 
-    int batchSize = processorConfiguration.getInt("batchSize");
+    int batchSize = processorConfiguration.getInt(SingerConfigDef.PROCESS_BATCH_SIZE);
     processorConfiguration.setThrowExceptionOnMissing(false);
     // Default to processingIntervalInSecondsMin.
     long maxIntervalInMillis = minIntervalInMillis;
@@ -1135,10 +1136,16 @@ public class LogConfigUtils {
           processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_MEMORY_EFFICIENCY));
     }
     config.setProcessingTimeSliceInMilliseconds(processingTimeSliceInMilliseconds);
-    
-    if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING)) {
-      config.setEnableDeciderBasedSampling(
-          processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING));
+
+    if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_DECIDER_BASED_SAMPLING)) {
+      SamplingType samplingType = SamplingType.valueOf(
+          processorConfiguration.getString(SingerConfigDef.PROCESS_DECIDER_BASED_SAMPLING).toUpperCase()
+      );
+      config.setDeciderBasedSampling(samplingType);
+    } else if (processorConfiguration.containsKey(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING)) {
+      if (processorConfiguration.getBoolean(SingerConfigDef.PROCESS_ENABLE_DECIDER_BASED_SAMPLING_SAMPLING)) {
+        config.setDeciderBasedSampling(SamplingType.MESSAGE);
+      }
     }
     return config;
   }

--- a/singer/src/test/java/com/pinterest/singer/monitor/DefaultLogMonitorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/monitor/DefaultLogMonitorTest.java
@@ -1,0 +1,78 @@
+package com.pinterest.singer.monitor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.config.Decider;
+import com.pinterest.singer.thrift.configuration.LogStreamProcessorConfig;
+import com.pinterest.singer.thrift.configuration.SamplingType;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+public class DefaultLogMonitorTest {
+
+  @Test
+  public void testIsLogStreamInactive() throws Exception {
+    SingerConfig singerConfig = new SingerConfig();
+    DefaultLogMonitor logMonitor = new DefaultLogMonitor(1, singerConfig);
+    LogStreamProcessorConfig lspc = new LogStreamProcessorConfig();
+    SingerLogConfig slc = new SingerLogConfig("test", "/tmp", "thrift.log", lspc, null, null);
+    slc.setLogDecider("test_decider");
+    SingerLog singerLog = new SingerLog(slc);
+    LogStream logStream = new LogStream(singerLog, "thrift.log");
+    Decider.setInstance(new HashMap<>());
+
+    // should always be active if decider doesn't exist
+    for (SamplingType type : new SamplingType[]{SamplingType.NONE, SamplingType.MESSAGE, SamplingType.INSTANCE}) {
+      lspc.setDeciderBasedSampling(type);
+      for (int i : new int[]{0, 1, 100}) {
+        logMonitor.setInstanceLevelSamplingThresholdValue(i);
+        assertFalse(logMonitor.isLogStreamInactive(logStream));
+      }
+    }
+
+    lspc.setDeciderBasedSampling(SamplingType.INSTANCE);
+
+    Decider.getInstance().getDeciderMap().put("test_decider", 0);
+    // should always be inactive if decider set to 0
+    for (int i : new int[]{0, 1, 100}) {
+      logMonitor.setInstanceLevelSamplingThresholdValue(i);
+      assertTrue(logMonitor.isLogStreamInactive(logStream));
+    }
+
+    // should not be inactive when the threshold value is < 10
+    Decider.getInstance().getDeciderMap().put("test_decider", 10);
+    for (int i : new int[]{0, 9}) {
+      logMonitor.setInstanceLevelSamplingThresholdValue(i);
+      assertFalse(logMonitor.isLogStreamInactive(logStream));
+    }
+    for (int i : new int[]{10, 11, 100}) {
+      logMonitor.setInstanceLevelSamplingThresholdValue(i);
+      assertTrue(logMonitor.isLogStreamInactive(logStream));
+    }
+
+    // should always be active as long as decider is not 0 if the sampling type is not INSTANCE level
+    for (SamplingType type : new SamplingType[]{SamplingType.NONE, SamplingType.MESSAGE}) {
+      lspc.setDeciderBasedSampling(type);
+      Decider.getInstance().getDeciderMap().put("test_decider", 0);
+      // should always be inactive if decider set to 0
+      for (int i : new int[]{0, 1, 100}) {
+        logMonitor.setInstanceLevelSamplingThresholdValue(i);
+        assertTrue(logMonitor.isLogStreamInactive(logStream));
+      }
+
+      // should not be inactive once the threshold value is >= 10
+      Decider.getInstance().getDeciderMap().put("test_decider", 10);
+      for (int i : new int[]{0, 9, 10, 11, 100}) {
+        logMonitor.setInstanceLevelSamplingThresholdValue(i);
+        assertFalse(logMonitor.isLogStreamInactive(logStream));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is to add another type of sampling besides the existing message-level sampling. Instance level sampling allows a logstream to be enabled/disabled by a percentage of the fleet, rather than a percentage of the messages per host. This allows canary-style rollouts of logs. Another minor improvement is logstreams that have a zero-value decider will be removed from the actively monitored logstreams, thus stop getting tracked in the stuck logstream monitor.