### PR TITLE
Fix Singer textReader bug using wrong config for max message size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.58</version>
+    <version>0.8.0.59</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.58</version>
+    <version>0.8.0.59</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.58</version>
+        <version>0.8.0.59</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -1013,7 +1013,7 @@ public class LogConfigUtils {
     textReaderConfiguration.setThrowExceptionOnMissing(true);
     int readerBufferSize = textReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
     Preconditions.checkArgument(readerBufferSize > 0, "Invalid readerBufferSize");
-    int maxMessageSize = textReaderConfiguration.getInt(SingerConfigDef.READER_BUFFER_SIZE, SingerConfigDef.DEFAULT_READER_BUFFER_SIZE);
+    int maxMessageSize = textReaderConfiguration.getInt(SingerConfigDef.MAX_MESSAGE_SIZE, SingerConfigDef.DEFAULT_MAX_MESSAGE_SIZE);
     Preconditions.checkArgument(maxMessageSize > 0, "Invalid maxMessageSize");
     int numMessagesPerLogMessage = textReaderConfiguration.getInt("numMessagesPerLogMessage");
     Preconditions.checkArgument(numMessagesPerLogMessage > 0, "Invalid numMessagesPerLogMessage");

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.58</version>
+    <version>0.8.0.59</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Singer text reader is using the wrong config for max message size. Bump version to 0.8.0.59 as well.