### PR TITLE
ThriftLogFileReader header behaviour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.61</version>
+    <version>0.8.0.62</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.61</version>
+    <version>0.8.0.62</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.61</version>
+        <version>0.8.0.62</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
@@ -94,6 +94,7 @@ public class ThriftLogFileReader implements LogFileReader {
       long byteOffset,
       int readBufferSize,
       int maxMessageSize,
+      String hostname,
       Map<String, ByteBuffer> headers) throws Exception {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(path));
     Preconditions.checkArgument(byteOffset >= 0);
@@ -103,6 +104,11 @@ public class ThriftLogFileReader implements LogFileReader {
     this.path = path;
     this.maxMessageSize = maxMessageSize;
     this.maxMessageSizeInternal = maxMessageSize * 10;
+
+    if (headers != null) {
+      headers.put("hostname", SingerUtils.getByteBuf(hostname));
+      headers.put("file", SingerUtils.getByteBuf(path));
+    }
 
     this.thriftReader = new ThriftReader(
         path, new LogMessageFactory(), new BinaryProtocolFactory(), readBufferSize,

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReaderFactory.java
@@ -17,6 +17,7 @@ package com.pinterest.singer.reader;
 
 import com.pinterest.singer.common.LogStream;
 import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
@@ -62,6 +63,7 @@ public class ThriftLogFileReaderFactory implements LogFileReaderFactory {
           byteOffset,
           readerConfig.getReaderBufferSize(),
           readerConfig.getMaxMessageSize(),
+          SingerUtils.getHostNameBasedOnConfig(logStream, SingerSettings.getSingerConfig()),
           readerConfig.isSetEnvironmentVariables() ?
           new HashMap<>(readerConfig.getEnvironmentVariables()) : null
       );

--- a/singer/src/test/java/com/pinterest/singer/reader/ThriftLogFileReaderTest.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/ThriftLogFileReaderTest.java
@@ -58,7 +58,7 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
 
     // Open reader which cap the log message at 500 bytes
-    LogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 500, null);
+    LogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 500,"localhost", null);
     int count = 0;
     for (int i = 0; i < 403; i++) {
       try {
@@ -95,7 +95,7 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
 
     // Open reader which cap the log message at 500 bytes
-    LogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 500, null);
+    LogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 500, "localhost", null);
     try {
       // Seek to start offset.
       reader.setByteOffset(startOffset);
@@ -111,7 +111,7 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
     }
 
     // Open reader.
-    reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 16000, null);
+    reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 16000, "localhost", null);
     List<LogMessageAndPosition> messagesRead = Lists.newArrayListWithExpectedSize(3);
     try {
       // Seek to start offset.
@@ -141,10 +141,12 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
     }
 
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
+    HashMap<String, ByteBuffer> map = new HashMap<>();
+    map.put("test", ByteBuffer.wrap("test_value".getBytes()));
 
     // Open reader.
-    ThriftLogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 16000,
-        Collections.singletonMap("test", ByteBuffer.wrap("test_value".getBytes())));
+    ThriftLogFileReader reader = new ThriftLogFileReader(logStream, logger.getLogFile(), path, 0L, 16000, 16000, "localhost",
+        map);
     List<LogMessageAndPosition> messagesRead = Lists.newArrayListWithExpectedSize(3);
     try {
       // Read log file until no more messages.
@@ -152,9 +154,11 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
       while (message != null) {
         messagesRead.add(message);
         assertNotNull(message.getInjectedHeaders());
-        assertEquals(1, message.getInjectedHeaders().size());
+        assertEquals(1 + 2, message.getInjectedHeaders().size());
         assertTrue(message.getInjectedHeaders().containsKey("test"));
         assertTrue(Arrays.equals("test_value".getBytes(), message.getInjectedHeaders().get("test").array()));
+        assertTrue(message.getInjectedHeaders().containsKey("hostname"));
+        assertTrue(message.getInjectedHeaders().containsKey("file"));
         message = reader.readLogMessageAndPosition();
       }
     } finally {

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.61</version>
+    <version>0.8.0.62</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Update ThriftLogFileReader header injection logic to be consistent with TextLogFileReader, bump version to 0.8.0.62