### PR TITLE
Initial implementation of AdminServer with draining command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.63</version>
+    <version>0.8.0.64</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.63</version>
+    <version>0.8.0.64</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -261,6 +261,30 @@ struct KubeConfig {
 
 }
 
+struct AdminConfig {
+
+  /**
+   * socket file of the admin server
+   */
+  1: optional string socketFile = "/tmp/singer/admin.sock"
+
+  /**
+   * allowed uids
+   */
+  2: optional list<i64> allowedUids = [0]
+
+  /**
+  *
+  */
+  3: optional i32 defaultDeletionTimeoutInSeconds = 3600;
+
+  /**
+   *
+   */
+  4: optional i32 deletionCheckIntervalInSeconds = 20;
+
+}
+
 /**
  * The singer config, synthesized from both the singer's own config and possible user config files.
  */
@@ -374,5 +398,12 @@ struct SingerConfig {
    */
 
   24: optional string configOverrideDir;
+
+  25: optional bool adminEnabled = false;
+
+  /**
+  *  Admin server configs
+  */
+  26: optional AdminConfig adminConfig;
 
 }

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.63</version>
+        <version>0.8.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>
@@ -200,6 +200,17 @@
 			<artifactId>metrics-core</artifactId>
 			<version>4.0.2</version>
 		</dependency>
+        <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-core</artifactId>
+            <version>2.4.0</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-server</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/singer/src/main/java/com/pinterest/singer/admin/AdminServer.java
+++ b/singer/src/main/java/com/pinterest/singer/admin/AdminServer.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.admin;
+
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.monitor.LogStreamManager;
+import com.pinterest.singer.thrift.configuration.AdminConfig;
+
+import com.twitter.ostrich.stats.Stats;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.newsclub.net.unix.AFUNIXSocketCredentials;
+import org.newsclub.net.unix.server.AFUNIXSocketServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class AdminServer extends AFUNIXSocketServer {
+  private static final Logger logger = LoggerFactory.getLogger(AdminServer.class.getName());
+  private static volatile AdminServer INSTANCE = null;
+
+  private final Set<Long> allowedUids;
+
+  private AdminServer(AdminConfig adminConfig) throws SocketException {
+    super(AFUNIXSocketAddress.of(new File(adminConfig.getSocketFile())));
+    allowedUids = new HashSet<>(adminConfig.getAllowedUids());
+  }
+
+  public static AdminServer getInstance(AdminConfig adminConfig) throws IOException {
+    if (INSTANCE == null) {
+      synchronized (AdminServer.class) {
+        if (INSTANCE == null) {
+          INSTANCE = new AdminServer(adminConfig);
+        }
+      }
+    }
+    return INSTANCE;
+  }
+
+  public void init() throws InterruptedException {
+    this.startAndWait(500, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  protected void onServerStarting() {
+    logger.info("AdminServer starting...");
+    Stats.setGauge(SingerMetrics.ADMIN_SERVER_STARTED, 1);
+  }
+
+  @Override
+  protected void onListenException(Exception e) {
+    logger.warn("Exception when listening", e);
+  }
+
+  @Override
+  protected void onSocketExceptionDuringAccept(SocketException e) {
+    logger.warn("Exception during accept", e);
+  }
+
+  @Override
+  protected void onSocketExceptionAfterAccept(Socket socket, SocketException e) {
+    logger.warn("Exception after accept", e);
+  }
+
+  @Override
+  protected void onServingException(Socket socket, Exception e) {
+    logger.warn("Exception when serving", e);
+  }
+
+  @Override
+  protected void onServerStopped(ServerSocket socket) {
+    Stats.setGauge(SingerMetrics.ADMIN_SERVER_STARTED, 0);
+  }
+
+  @Override
+  protected void doServeSocket(Socket socket) throws IOException {
+    logger.info("Serving socket...");
+    if (socket instanceof AFUNIXSocket) {
+      doServeSocket((AFUNIXSocket) socket);
+    } else {
+      logger.error("Invalid socket type: " + socket.getClass().getName());
+      throw new IOException("Socket type is not supported");
+    }
+  }
+
+  private void doServeSocket(AFUNIXSocket socket) throws IOException{
+    if (validateCredentials(socket.getPeerCredentials())) {
+      try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+        String line;
+        while ((line = reader.readLine()) != null) {
+          logger.info("read command " + line + " from peer with credentials: " + socket.getPeerCredentials());
+          Command cmd = null;
+          switch (line.trim()) {
+            case "stop":
+              cmd = new StopCommand();
+              break;
+            default:
+              throw new UnsupportedOperationException("Invalid command");
+          }
+          cmd.execute(socket);
+          logger.info("execution complete");
+        }
+      }
+    } else {
+      // do nothing and wait for socket to close since the credentials aren't matching
+    }
+  }
+
+  private boolean validateCredentials(AFUNIXSocketCredentials credentials) {
+    logger.info("Connection from uid: " + credentials.getUid());
+    return allowedUids.contains(credentials.getUid());
+  }
+
+  private interface Command {
+    void execute(AFUNIXSocket socket);
+  }
+
+  private static class StopCommand implements Command {
+
+    @Override
+    public void execute(AFUNIXSocket socket) {
+      logger.info("Stopping all logstreams...");
+      try {
+        LogStreamManager.getInstance().drainAndStopLogStreams().get();
+        logger.info("All logstreams stopped.");
+      } catch (Exception e) {
+        logger.error("Failed to drain and stop logstreams", e);
+      }
+      try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()))) {
+        writer.write("done");
+        writer.flush();
+      } catch (IOException ioException) {
+        logger.error("Failed to write to socket, terminating process.");
+        System.exit(0);
+      }
+    }
+  }
+
+}

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -75,7 +75,14 @@ public class SingerConfigDef {
   public static final String KUBE_POLL_FREQUENCY_SECONDS = "pollFrequencyInSeconds";
   public static final String KUBE_POD_LOG_DIR = "podLogDirectory";
   public static final String KUBE_DEFAULT_DELETION_TIMEOUT = "defaultDeletionTimeoutInSeconds";
-  
+
+  public static final String SINGER_ADMIN_CONFIG_PREFIX = "singer.admin.";
+  public static final String ADMIN_SOCKET_FILE = "socket.file";
+  public static final String ADMIN_ALLOWED_UIDS = "allowed.uids";
+  public static final String ADMIN_DEFAULT_DELETION_TIMEOUT = "defaultDeletionTimeoutInSeconds";
+  public static final String ADMIN_DELETION_CHECK_INTERVAL = "deletionCheckIntervalInSeconds";
+
+
   public static final int SINGER_EXIT_FSM_EXCEPTION = 200;
   public static final int SINGER_EXIT_FSEF_EXCEPTION = 201;
 

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -90,7 +90,10 @@ public class SingerMetrics {
   // Time elapsed between when Kubernetes deleted the pod and when Singer wrote tombstone marker
   public static final String POD_DELETION_TIME_ELAPSED = KUBE_PREFIX + "pod_deletion_time_elapsed";
   public static final String NUMBER_OF_PODS = KUBE_PREFIX + "number_of_pods";
-  
+
+  public static final String ADMIN_PREFIX = SINGER_PREIX + "admin.";
+  public static final String ADMIN_SERVER_STARTED = ADMIN_PREFIX + "admin_server_started";
+
   static {
     // note this needs to be initialized since we update this
     // gauge based on current value

--- a/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerSettings.java
@@ -15,6 +15,7 @@
  */
 package com.pinterest.singer.common;
 
+import com.pinterest.singer.admin.AdminServer;
 import com.pinterest.singer.common.errors.SingerLogException;
 import com.pinterest.singer.config.SingerDirectoryWatcher;
 import com.pinterest.singer.environment.Environment;
@@ -33,6 +34,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -207,7 +209,13 @@ public final class SingerSettings {
         instance.start();
       }
     }
-    
+
+    if (singerConfig != null && singerConfig.isAdminEnabled()) {
+      LOG.info("AdminServer is enabled");
+      new File(singerConfig.getAdminConfig().getSocketFile()).getParentFile().mkdirs();
+      AdminServer.getInstance(singerConfig.getAdminConfig()).start();
+    }
+
     if (singerConfig != null && singerConfig.isSetLogMonitorConfig()) {
       LOG.info("Log monitor started");
       int monitorIntervalInSecs = singerConfig.getLogMonitorConfig().getMonitorIntervalInSecs();

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.63</version>
+    <version>0.8.0.64</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
This commit adds an AdminServer module that will allow admin operations to be performed via a Unix domain socket (UDS). UDS server implementation is backed by the junixsocket dependency. Besides file permissions, there is also a simple pid based allowlist for commands. 
The only command provided now is the `stop` command, which is will allow Singer to drain logs before getting ready to be terminated.
A simple way to perform this operation from shell would be to use `nc` (nc-freebsd) with the following command:
`echo "stop" | nc -U /tmp/singer/admin.sock`
The command will block until all logstreams are drained, or Singer is terminated. The command will send back the message `done` to the connection when the draining is complete, signaling the script that Singer is ready to be terminated. If the socket is lost during the draining, Singer will terminate itself.