### PR TITLE
Make partitioner configurable and add FixedPartitionsPartitioner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.64</version>
+    <version>0.8.0.65</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.64</version>
+    <version>0.8.0.65</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/common.thrift
+++ b/singer-commons/src/main/thrift/common.thrift
@@ -31,4 +31,5 @@ struct KafkaProducerConfig {
  13: optional i32 retries = 5;
  14: optional i32 bufferMemory = 33554432;
  15: optional i32 lingerMs = 10;
+ 16: optional map<string, string> partitionerConfigs;
 }

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.64</version>
+        <version>0.8.0.65</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -66,6 +66,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
+import java.util.Collections;
 import java.util.HashMap;
 import org.apache.commons.configuration.AbstractConfiguration;
 import org.apache.commons.configuration.Configuration;
@@ -921,6 +922,18 @@ public class LogConfigUtils {
             "Unknown partitioner class: " + partitionClass);
       }
       kafkaProducerConfig.setPartitionerClass(partitionClass);
+      Iterator<String> partitionerConfigKeys = producerConfiguration.getKeys("partitioner");
+      Map<String, String> partitionerConfigs = null;
+      while (partitionerConfigKeys.hasNext()) {
+        String partitionerConfigKey = partitionerConfigKeys.next();
+        if (partitionerConfigs == null) partitionerConfigs = new HashMap<>();
+        partitionerConfigs.put(partitionerConfigKey, producerConfiguration.getString(partitionerConfigKey));
+      }
+      if (partitionerConfigs != null) {
+        kafkaProducerConfig.setPartitionerConfigs(partitionerConfigs);
+      } else {
+        kafkaProducerConfig.setPartitionerConfigs(Collections.emptyMap());
+      }
     } else {
       kafkaProducerConfig.setPartitionerClass(SingerConfigDef.DEFAULT_PARTITIONER);
     }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaMessagePartitioner.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaMessagePartitioner.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.writer;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.kafka.common.PartitionInfo;
 
@@ -27,7 +28,9 @@ import org.apache.kafka.common.PartitionInfo;
  * - Returned partition id must be absolute
  */
 public interface KafkaMessagePartitioner {
-  
-  public int partition(Object messageKey, List<PartitionInfo> partitions);
+  default void configure(Map<String, String> partitionerConfig) {
+
+  }
+  int partition(Object messageKey, List<PartitionInfo> partitions);
 
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/KafkaWriter.java
@@ -154,10 +154,10 @@ public class KafkaWriter implements LogStreamWriter {
     this.producerConfig = producerConfig;
     // cache the class and instance instead of doing reflections each time 
     try {
-      @SuppressWarnings("unchecked")
-      Class<KafkaMessagePartitioner> partitionerClass 
-            = (Class<KafkaMessagePartitioner>) Class.forName(partitionerClassName);
-      partitioner = partitionerClass.getConstructor().newInstance();
+      partitioner = Class.forName(partitionerClassName).asSubclass(KafkaMessagePartitioner.class).newInstance();
+      if (producerConfig.isSetPartitionerConfigs()) {
+        partitioner.configure(producerConfig.getPartitionerConfigs());
+      }
     } catch (Exception e) {
       LOG.error("Invalid partitioner configuration", e);
       throw e;

--- a/singer/src/main/java/com/pinterest/singer/writer/partitioners/FixedPartitionsPartitioner.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/partitioners/FixedPartitionsPartitioner.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2019 Pinterest, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.writer.partitioners;
+
+import com.pinterest.singer.writer.KafkaMessagePartitioner;
+
+import org.apache.kafka.common.PartitionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+/**
+ * This partition is used to group a batch of messages into one of fixed number of partitions
+ * This will potentially help out with both the compression ratio and connection count.
+ * The number of partitions should be chosen as a multiplier for a reasonable producer-to-partition ratio.
+ * Default behaviour (with no configs) would be similar to SinglePartitionPartitioner
+ */
+public class FixedPartitionsPartitioner implements KafkaMessagePartitioner {
+  public static final String PARTITIONER_PARTITION_COUNT_KEY = "partitioner.partitionCount";
+  private static final Logger logger = LoggerFactory.getLogger(FixedPartitionsPartitioner.class);
+
+  private final Map<Integer, List<Integer>> partitionMap = new HashMap<>();
+  private final ThreadLocalRandom random = ThreadLocalRandom.current();
+  private int partitionCount = 1;
+
+
+  @Override
+  public void configure(Map<String, String> partitionerConfig) {
+    if (partitionerConfig != null) {
+      KafkaMessagePartitioner.super.configure(partitionerConfig);
+      partitionCount = Integer.parseInt(partitionerConfig.getOrDefault(PARTITIONER_PARTITION_COUNT_KEY, "1"));
+      logger.info("Partitioner configured to partition to at most " + partitionCount + " partitions");
+    }
+  }
+
+  public int partition(Object object, List<PartitionInfo> partitions) {
+    int numOfPartitions = partitions.size();
+
+    /* For each partition count during Singer's lifetime, we derive a fixed set of different partitions for
+       that partition count of the topic to reduce the number of brokers this host reaches out to.
+     */
+    if (!partitionMap.containsKey(numOfPartitions)){
+      List<Integer> selectedPartitions = new ArrayList<>();
+      while (selectedPartitions.size() < Math.min(partitionCount, numOfPartitions)) {
+        int selectedPartition = Math.abs(random.nextInt(numOfPartitions));
+        while (selectedPartitions.contains(selectedPartition)) {
+          selectedPartition = Math.abs(random.nextInt(numOfPartitions));
+        }
+        selectedPartitions.add(selectedPartition);
+      }
+      partitionMap.put(numOfPartitions, selectedPartitions);
+      logger.info("For " + numOfPartitions + " partitions, delivering to partitions " + selectedPartitions.stream().map(Object::toString).collect(Collectors.joining(" ")));
+    }
+    List<Integer> listOfPartitions = partitionMap.get(numOfPartitions);
+    return listOfPartitions.get(random.nextInt(listOfPartitions.size()));
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/partitioners/TestFixedNumberPartitionPartitioner.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/partitioners/TestFixedNumberPartitionPartitioner.java
@@ -1,0 +1,74 @@
+package com.pinterest.singer.writer.partitioners;
+
+import com.pinterest.singer.writer.KafkaMessagePartitioner;
+
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class TestFixedNumberPartitionPartitioner {
+  @Test
+  public void testFixedPartitionsPartitioner() {
+    KafkaMessagePartitioner partitioner = new FixedPartitionsPartitioner();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(FixedPartitionsPartitioner.PARTITIONER_PARTITION_COUNT_KEY, "2");
+    partitioner.configure(configs);
+
+    List<PartitionInfo> partitions = new ArrayList<>(Arrays.asList(
+        new PartitionInfo("topix", 0, new Node(0, "0", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topix", 1, new Node(0, "0", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topix", 2, new Node(0, "0", 9092, "us-east-1d"), null, null),
+        new PartitionInfo("topix", 4, new Node(0, "0", 9092, "us-east-1d"), null, null),
+        new PartitionInfo("topix", 3, new Node(0, "0", 9092, "us-east-1e"), null, null)));
+
+    Set<Integer> partitionSet = new HashSet<>();
+    for (int i = 0; i < 1000; i++) {
+      int p = partitioner.partition(null, partitions);
+      partitionSet.add(p);
+    }
+    Assert.assertEquals("Should have only 2 partitions", 2, partitionSet.size());
+
+    for (int i = 5; i < 500; i++) {
+      partitions.add(new PartitionInfo("topix", 0, new Node(i, "0", 9092, "us-east-1a"), null, null));
+    }
+
+    Set<Integer> newPartitionSet = new HashSet<>();
+    for (int i = 0; i < 1000; i++) {
+      int p = partitioner.partition(null, partitions);
+      newPartitionSet.add(p);
+    }
+    Assert.assertEquals("Should have only 2 partitions", 2, newPartitionSet.size());
+    Assert.assertNotEquals("The partitions should be different between two runs (very low chance that the two are identical)", partitionSet, newPartitionSet);
+
+  }
+
+  @Test
+  public void testFixedPartitionsPartitionerNumPartitionSmallerThanConfig() {
+    KafkaMessagePartitioner partitioner = new FixedPartitionsPartitioner();
+    Map<String, String> configs = new HashMap<>();
+    configs.put(FixedPartitionsPartitioner.PARTITIONER_PARTITION_COUNT_KEY, "5");
+    partitioner.configure(configs);
+
+    List<PartitionInfo> partitions = new ArrayList<>(Arrays.asList(
+        new PartitionInfo("topix", 0, new Node(0, "0", 9092, "us-east-1a"), null, null),
+        new PartitionInfo("topix", 1, new Node(0, "0", 9092, "us-east-1c"), null, null),
+        new PartitionInfo("topix", 2, new Node(0, "0", 9092, "us-east-1d"), null, null)));
+
+    Set<Integer> partitionSet = new HashSet<>();
+    for (int i = 0; i < 1000; i++) {
+      int p = partitioner.partition(null, partitions);
+      partitionSet.add(p);
+    }
+    Assert.assertEquals("Should have only 3 partitions", 3, partitionSet.size());
+  }
+
+}

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.64</version>
+    <version>0.8.0.65</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Allow configs to be passed to the partitioner via `writer.kafka.producerConfig.partitioner.<config>` keys, and add a partitioner that allows fixed number of partitions to be written to (extension of `SinglePartitionPartitioner`)