### PR TITLE
Fix incorrect usage of ThreadLocalRandom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.65</version>
+    <version>0.8.0.66</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.65</version>
+    <version>0.8.0.66</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.65</version>
+        <version>0.8.0.66</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/writer/partitioners/FixedPartitionsPartitioner.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/partitioners/FixedPartitionsPartitioner.java
@@ -40,7 +40,6 @@ public class FixedPartitionsPartitioner implements KafkaMessagePartitioner {
   private static final Logger logger = LoggerFactory.getLogger(FixedPartitionsPartitioner.class);
 
   private final Map<Integer, List<Integer>> partitionMap = new HashMap<>();
-  private final ThreadLocalRandom random = ThreadLocalRandom.current();
   private int partitionCount = 1;
 
 
@@ -62,9 +61,9 @@ public class FixedPartitionsPartitioner implements KafkaMessagePartitioner {
     if (!partitionMap.containsKey(numOfPartitions)){
       List<Integer> selectedPartitions = new ArrayList<>();
       while (selectedPartitions.size() < Math.min(partitionCount, numOfPartitions)) {
-        int selectedPartition = Math.abs(random.nextInt(numOfPartitions));
+        int selectedPartition = Math.abs(ThreadLocalRandom.current().nextInt(numOfPartitions));
         while (selectedPartitions.contains(selectedPartition)) {
-          selectedPartition = Math.abs(random.nextInt(numOfPartitions));
+          selectedPartition = Math.abs(ThreadLocalRandom.current().nextInt(numOfPartitions));
         }
         selectedPartitions.add(selectedPartition);
       }
@@ -72,6 +71,6 @@ public class FixedPartitionsPartitioner implements KafkaMessagePartitioner {
       logger.info("For " + numOfPartitions + " partitions, delivering to partitions " + selectedPartitions.stream().map(Object::toString).collect(Collectors.joining(" ")));
     }
     List<Integer> listOfPartitions = partitionMap.get(numOfPartitions);
-    return listOfPartitions.get(random.nextInt(listOfPartitions.size()));
+    return listOfPartitions.get(ThreadLocalRandom.current().nextInt(listOfPartitions.size()));
   }
 }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.65</version>
+    <version>0.8.0.66</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Previously the ThreadLocalRandom instance was kept as a member of the partitioner and populated during configure phase, causing the random seeds to be the same each time.