### PR TITLE
Allow logstreams to be skipped during draining

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.67</version>
+    <version>0.8.0.68</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.67</version>
+    <version>0.8.0.68</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -212,6 +212,11 @@ struct SingerLogConfig {
    *  audit configuration for the logStreams created from this SingerLogConfig
    */
   13: optional loggingaudit_config.AuditConfig auditConfig;
+
+  /**
+   *  this log will be skipped directly when draining is enabled
+   */
+  14: optional bool skipDraining = false;
 }
 
 /**

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.67</version>
+        <version>0.8.0.68</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -100,4 +100,5 @@ public class SingerConfigDef {
   public static final int DEFAULT_READER_BUFFER_SIZE = 10240;
 
   public static final String PROCESS_BATCH_SIZE = "batchSize";
+  public static final String SKIP_DRAINING = "skipDraining";
 }

--- a/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
@@ -647,6 +647,12 @@ public class LogStreamManager implements PodWatcher {
       Entry<String, Collection<LogStream>> entry = dirStreamEntryIterator.next();
       for (Iterator<LogStream> logStreamIterator = entry.getValue().iterator(); logStreamIterator.hasNext();) {
         LogStream logStream = logStreamIterator.next();
+        if (logStream.getSingerLog().getSingerLogConfig().isSkipDraining()) {
+          // don't track this logstream during draining
+          LOG.info("Skip draining " + logStream);
+          logStreamIterator.remove();
+          continue;
+        }
         // if we have exceeded the timeout then remove this logstream
         // completed cycle time is updated by DefaultLogMonitor
         long lastCompleteCycleTime = logStream.getLastCompleteCycleTime();

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -563,6 +563,10 @@ public class LogConfigUtils {
          config.setEnableLoggingAudit(false);
       }
     }
+
+    if (logConfiguration.containsKey(SingerConfigDef.SKIP_DRAINING)) {
+      config.setSkipDraining(logConfiguration.getBoolean(SingerConfigDef.SKIP_DRAINING));
+    }
     
     ts = System.currentTimeMillis() - ts;
     LOG.debug("Loaded:"+logName+" configuration in "+ts+"ms");

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.67</version>
+    <version>0.8.0.68</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
This allows log configs to specify `skipDraining` and skip the draining. This is useful for application logs that cannot be stopped but not critical.