### PR TITLE
Add try-catch during initialize phase to deal with log rotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.68</version>
+    <version>0.8.0.69</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.68</version>
+    <version>0.8.0.69</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.68</version>
+        <version>0.8.0.69</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/LogStream.java
+++ b/singer/src/main/java/com/pinterest/singer/common/LogStream.java
@@ -169,8 +169,12 @@ public class LogStream {
       logFilePaths.clear();
       logFilePathsIndex.clear();
       for (File entry : logFiles) {
-        long inode = SingerUtils.getFileInode(entry.toPath());
-        append(new LogFile(inode), entry.toPath().toString());
+        try {
+          long inode = SingerUtils.getFileInode(entry.toPath());
+          append(new LogFile(inode), entry.toPath().toString());
+        } catch (Exception e) {
+          LOG.warn("Could not parse inode of file " + entry.toPath() + ", dropping it from logstream " + this);
+        }
       }
     }
     OpenTsdbMetricConverter.incr(SingerMetrics.LOGSTREAM_INITIALIZE, 1,

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.68</version>
+    <version>0.8.0.69</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Previously if a log file is deleted during logstream initialization phase, an NPE will cause the logstream to be empty.