### PR TITLE
Fix metrics tagging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.70</version>
+    <version>0.8.0.71</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.70</version>
+    <version>0.8.0.71</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.70</version>
+        <version>0.8.0.71</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -434,7 +434,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
     LogPosition position = new LogPosition(firstLogFileAndPath.getLogFile(), 0L);
     LOG.info("Process log stream: {} from beginning of the stream: {}", stream, position);
     OpenTsdbMetricConverter.incr(
-        "singer.processor.committed_position_reset", 1, "log=" + logStream.getLogStreamName());
+        "singer.processor.committed_position_reset", 1, "log=" + logStream.getSingerLog().getLogName());
     return position;
   }
 

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.70</version>
+    <version>0.8.0.71</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
`singer.processor.committed_position_reset` metric was using the wrong log tag, causing high cardinality for some use cases