### PR TITLE
Add default retention of 2hrs for Singer

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -190,7 +190,7 @@ struct SingerLogConfig {
    * the maximum retention of a log file based on its last modification time.
    * Default value is -1 that means that there is no log retention enforcement by Singer.
    */
-  9: optional i32 logRetentionInSeconds = -1;
+  9: optional i32 logRetentionInSeconds = 7200;
   10: optional bool enableHeadersInjector = false;
   /**
    * headers injector class


### PR DESCRIPTION
Add default retention of 2hrs for Singer, currently there is no default retention for Singer. 2hrs is a low enough value for data to be saved for local investigation without leaving large amount of unused data.