### PR TITLE
update vulnerable dependency: commons-io:commons-io

### DIFF
--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION

Hi! We spot a vulnerable dependency in your project, which might threaten your software. We also found another project that uses the same vulnerable dependency in a similar way as you did, and they have upgraded the dependency. We, thus, believe that your project is highly possible to be affected by this vulnerability similarly. The following shows the detailed information. 

## Vulnerability description
+ CVE: **CVE-2021-29425**
+ Vulnerable dependency: **commons-io:commons-io:2.4**
+ Vulnerable function: **org.apache.commons.io.FilenameUtils:getPrefixLength(java.lang.String)**
+ Invocation Path: 
```java
com.pinterest.singer.config.DirectorySingerConfigurator:parseSingerConfig()
 ⬇️ 
org.apache.commons.io.FilenameUtils:concat(java.lang.String,java.lang.String)
 ⬇️ 
...
 ⬇️ 
org.apache.commons.io.FilenameUtils:getPrefixLength(java.lang.String)
```

## Upgrade example
Another project also used the same dependency with a similar invocation path, and they have taken actions to resolve this issue.
+ Project: https://github.com/OpenWiseSolutions/openhub-framework
+ Action commit:https://github.com/OpenWiseSolutions/openhub-framework/commit/59b982fbaffd7e99c84d135807b2038cf8d804a4
+ Invocation Path:
```java
org.openhubframework.openhub.core.common.file.DefaultFileRepository:commitFile(java.lang.String,java.lang.String,org.openhubframework.openhub.api.file.FileContentTypeExtEnum,java.util.List)
 ⬇️ 
org.apache.commons.io.FilenameUtils:concat(java.lang.String,java.lang.String)
 ⬇️ 
...
 ⬇️ 
org.apache.commons.io.FilenameUtils:getPrefixLength(java.lang.String)
```

Therefore, you might also need to upgrade this dependency. Hope this can help you! 😄
