### PR TITLE
Add K8s uid support for pod log directories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.74</version>
+    <version>0.8.0.75</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.74</version>
+    <version>0.8.0.75</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.74</version>
+        <version>0.8.0.75</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
@@ -267,11 +267,22 @@ public class KubeService implements Runnable {
             JsonArray ary = obj.get("items").getAsJsonArray();
             for (int i = 0; i < ary.size(); i++) {
                 JsonObject metadata = ary.get(i).getAsJsonObject().get("metadata").getAsJsonObject();
+                // pod name
                 String name = metadata.get("name").getAsString();
-                podNames.add(name);
                 // to support namespace based POD directories
+                // pod namespace
                 String namespace = metadata.get("namespace").getAsString();
-                podNames.add(namespace + "_" + name);
+                // pod uid
+                String podUid = metadata.get("uid").getAsString();
+
+                // coexist of 2 format: namespace_podname or namespace_podname_uid
+                String formatOne = namespace + "_" + name;
+                String formatTwo = namespace + "_" + name + "_" + podUid;
+                if (new File(podLogDirectory + '/' + formatOne).exists()) {
+                    podNames.add(formatOne);
+                } else {
+                    podNames.add(formatTwo);
+                }
                 LOG.debug("Found active POD name in JSON:" + name);
             }
         }

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
@@ -278,10 +278,16 @@ public class KubeService implements Runnable {
                 // coexist of 2 format: namespace_podname or namespace_podname_uid
                 String formatOne = namespace + "_" + name;
                 String formatTwo = namespace + "_" + name + "_" + podUid;
-                if (new File(podLogDirectory + '/' + formatOne).exists()) {
+                String path_format = podLogDirectory;
+                if (!podLogDirectory.endsWith("/")) {
+                    path_format = podLogDirectory + "/";
+                }
+                if (new File(path_format + formatOne).exists()) {
                     podNames.add(formatOne);
+                    LOG.debug("Added format one: " + formatOne);
                 } else {
                     podNames.add(formatTwo);
+                    LOG.debug("Added formate two: " + formatTwo);
                 }
                 LOG.debug("Found active POD name in JSON:" + name);
             }

--- a/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
+++ b/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.kubernetes;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -28,9 +29,8 @@ import java.nio.file.Files;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -99,8 +99,9 @@ public class TestKubeService {
     }
 
     @Test
-    public void testGoodPodFetch() throws KeyManagementException, ClientProtocolException, NoSuchAlgorithmException,
-            KeyStoreException, MalformedURLException, IOException {
+    public void testGoodPodFetch()
+        throws KeyManagementException, ClientProtocolException, NoSuchAlgorithmException,
+               KeyStoreException, MalformedURLException, IOException {
         registerGoodResponse();
 
         KubeConfig kubeConfig = new KubeConfig();
@@ -108,21 +109,43 @@ public class TestKubeService {
         Set<String> fetchPodNamesFromMetadata = poll.fetchPodNamesFromMetadata();
 
         // check uid count is correct
-        assertEquals(12, fetchPodNamesFromMetadata.size());
-        
-        Map<String, String> podToNamespaceMap = new HashMap<>();
-        podToNamespaceMap.put("enimanager-ppl56", "default");
-        podToNamespaceMap.put("zk-update-monitor-r1vlt", "default");
-        podToNamespaceMap.put("tcollector-q4qx8", "default");
-        podToNamespaceMap.put("metrics-agent-8vm9g", "default");
-        podToNamespaceMap.put("kubernetes-dashboard-1835568627-hhfhj", "kube-system");
-        podToNamespaceMap.put("test-ci-0", "kubernetes-plugin");
-        for (Entry<String, String> entry : podToNamespaceMap.entrySet()) {
-          String name = entry.getKey();
-          String namespace = entry.getValue();
-          assertTrue(fetchPodNamesFromMetadata.contains(name));
-          assertTrue(fetchPodNamesFromMetadata.contains(namespace + "_" + name));
+        assertEquals(6, fetchPodNamesFromMetadata.size());
+
+        List<String> podNameList = new ArrayList<>();
+        podNameList.add(
+            "default" + "_" + "enimanager-ppl56" + "_" + "b1a2a0c2-d3ab-11e7-a1db-0674200569b6");
+        podNameList.add("default" + "_" + "zk-update-monitor-r1vlt" + "_"
+            + "7d1d8b00-b532-11e7-b628-0674200569b6");
+        podNameList.add(
+            "default" + "_" + "tcollector-q4qx8" + "_" + "8ad2dba8-b84c-11e7-b628-0674200569b6");
+        podNameList.add(
+            "default" + "_" + "metrics-agent-8vm9g" + "_" + "bfc5f760-b8e1-11e7-b628-0674200569b6");
+        podNameList.add("kube-system" + "_" + "kubernetes-dashboard-1835568627-hhfhj" + "_"
+            + "a343643b-b936-11e7-b628-0674200569b6");
+        podNameList.add(
+            "kubernetes-plugin" + "_" + "test-ci-0" + "_" + "f084af12-cbe6-11e7-a1db-0674200569b6");
+        for (String podName : podNameList) {
+            assertTrue(fetchPodNamesFromMetadata.contains(podName));
         }
+    }
+
+    @Test
+    public void testPodFetchWithTwoFormats() throws IOException {
+        registerGoodResponse();
+
+        String firstFormat = "default_enimanager-ppl56";
+        String secondFormat = "default_enimanager-ppl56_b1a2a0c2-d3ab-11e7-a1db-0674200569b6";
+        String podDirectory = "target/kube";
+        File f = new File(podDirectory + "/" + firstFormat);
+        if (!f.exists()) {
+            f.mkdirs();
+        }
+        KubeConfig kubeConfig = new KubeConfig();
+        kubeConfig.setPodLogDirectory(podDirectory);
+        KubeService poll = new KubeService(kubeConfig);
+        Set<String> fetchPodNamesFromMetadata = poll.fetchPodNamesFromMetadata();
+        assertFalse(fetchPodNamesFromMetadata.contains(secondFormat));
+        f.delete();
     }
 
     @Test

--- a/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
+++ b/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
@@ -146,6 +146,13 @@ public class TestKubeService {
         Set<String> fetchPodNamesFromMetadata = poll.fetchPodNamesFromMetadata();
         assertFalse(fetchPodNamesFromMetadata.contains(secondFormat));
         f.delete();
+        f = new File(podDirectory + "/" + secondFormat);
+        if (!f.exists()) {
+            f.mkdirs();
+        }
+        fetchPodNamesFromMetadata = poll.fetchPodNamesFromMetadata();
+        assertFalse(fetchPodNamesFromMetadata.contains(firstFormat));
+        f.delete();
     }
 
     @Test

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.74</version>
+    <version>0.8.0.75</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Adding support for pod log directories with pod uid in their names: `namespace_name_uid` as well as the original format `namespace_name`. Note that for 1 unique `namespace` + `name` + `uid` combination, there can't be two directories, e.g: `somenamespace_xyz` and `somenamespace_xyz_123` won't be present at the same time.

Testing: Replace Singer jar with code changes in an EC2 host running singer in kubernetes mode. After enabling the `_uid` directories, it was verified that singer was able to pick up the logs inside every pod directory and properly generate the `.` file for CMP process to do cleanup.