### PR TITLE
Ignore pods running singer in dual mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.77</version>
+    <version>0.8.0.78</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.77</version>
+    <version>0.8.0.78</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -264,6 +264,12 @@ struct KubeConfig {
    */
   5: optional i32 kubePollStartDelaySeconds = 10;
 
+  /**
+  * Directory that serves as a flag that indicates
+  * a pod should be ingored
+  */
+  6: optional string ignorePodDirectory = "";
+
 }
 
 struct AdminConfig {

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.77</version>
+        <version>0.8.0.78</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -87,6 +87,7 @@ public class SingerMetrics {
   public static final String PODS_TOMBSTONE_MARKER = KUBE_PREFIX + "pod_tombstone_marker";
   public static final String PODS_DELETED = KUBE_PREFIX + "pod_deleted";
   public static final String PODS_CREATED = KUBE_PREFIX + "pod_created";
+  public static final String PODS_IGNORED = KUBE_PREFIX + "pod_ignored";
   // Time elapsed between when Kubernetes deleted the pod and when Singer wrote tombstone marker
   public static final String POD_DELETION_TIME_ELAPSED = KUBE_PREFIX + "pod_deletion_time_elapsed";
   public static final String NUMBER_OF_PODS = KUBE_PREFIX + "number_of_pods";

--- a/singer/src/main/java/com/pinterest/singer/tools/KubeServiceChecker.java
+++ b/singer/src/main/java/com/pinterest/singer/tools/KubeServiceChecker.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2019 Pinterest, Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *    http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,23 +27,28 @@ import com.pinterest.singer.thrift.configuration.SingerConfig;
  */
 public class KubeServiceChecker {
 
-	public static void main(String[] args) {
-		SingerConfig singerConfig = new SingerConfig();
-		singerConfig.setKubernetesEnabled(true);
-		singerConfig.setKubeConfig(new KubeConfig());
-        SingerSettings.setSingerConfig(singerConfig);
-		
-		KubeService service = KubeService.getInstance();
-		try {
-			Set<String> podUids = service.fetchPodNamesFromMetadata();
-			for (String puid : podUids) {
-				System.out.println(puid);
-			}
-		} catch (Exception e) {
-			System.err.println("Failed to fetch Pod IDs. Reason:"+e.getMessage());
-			e.printStackTrace();
-			System.exit(-1);
-		}
-	}
+  public static void main(String[] args) {
+    if (args.length < 1) {
+      System.out.println("Usage: KubeServiceChecker [singer_config_dir]");
+    }
+    SingerConfig singerConfig = new SingerConfig();
+    singerConfig.setKubernetesEnabled(true);
+    KubeConfig kubeConfig = new KubeConfig();
+    kubeConfig.setPodLogDirectory(args[0]);
+    singerConfig.setKubeConfig(kubeConfig);
+    SingerSettings.setSingerConfig(singerConfig);
+
+    KubeService service = KubeService.getInstance();
+    try {
+      Set<String> podUids = service.fetchPodNamesFromMetadata();
+      for (String puid : podUids) {
+        System.out.println(puid);
+      }
+    } catch (Exception e) {
+      System.err.println("Failed to fetch Pod IDs. Reason:" + e.getMessage());
+      e.printStackTrace();
+      System.exit(-1);
+    }
+  }
 
 }

--- a/singer/teletraan/conf/singer.kubernetes.properties
+++ b/singer/teletraan/conf/singer.kubernetes.properties
@@ -4,6 +4,7 @@ singer.ostrichPort = 2047
 
 singer.kubernetesEnabled = true
 singer.kubernetes.podLogDirectory = ${KUBERNETES_POD_LOG_DIRECTORY}
+singer.kubernetes.ignorePodDirectory = ${KUBERNETES_IGNORE_POD_DIRECTORY}
 singer.kubernetes.defaultDeletionTimeoutInSeconds = ${KUBERNETES_DEFAULT_DELETION_TIMEOUT_SECONDS}
 singer.kubernetes.deletionCheckIntervalInSeconds = ${KUBERNETES_DELETION_CHECK_INTERVAL_SECONDS}
 singer.kubernetes.kubePollStartDelaySeconds = ${KUBERNETES_POLL_START_DELAY_SECONDS}

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.77</version>
+    <version>0.8.0.78</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
To exclude pod log directories that have their dedicated logging agent, a flag named "ignorePodDirectory" is introduced. Singer will ignore the processing and monitoring of directories marked with this flag. For instance, if the pod log directory is `/var/log/podlogs/my_pod/` and the flag directory `ignorePodDirectory=Ignore`, singer will refrain from processing any data related to this specific pod if `/var/log/podlogs/my_pod/Ignore` exists