### PR TITLE
Add fleet level disable decider logic

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -422,4 +422,9 @@ struct SingerConfig {
     */
   27: optional string fsEventQueueImplementation;
 
+  /**
+   * Hostname Prefix regex pattern
+   */
+  28: optional string hostnamePrefixRegex = "-";
+
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -61,6 +61,8 @@ public class SingerMetrics {
   public static final String PROCESSOR_MESSAGE_KEY_SIZE_BYTES = "processor.message.key.size.bytes";
   public static final String PROCESSOR_MESSAGE_VALUE_SIZE_BYTES = "processor.message.value.size.bytes";
 
+  public static final String DISABLE_DECIDER_ACTIVE = "singer.processor.disable_decider_active";
+
   public static final String SKIPPED_BYTES = "singer.reader.skipped_bytes";
 
   public static final String WATERMARK_CREATION_FAILURE = "singer.watermark.creation.failure";

--- a/singer/src/main/java/com/pinterest/singer/config/Decider.java
+++ b/singer/src/main/java/com/pinterest/singer/config/Decider.java
@@ -120,7 +120,7 @@ public class Decider {
   public List<String> generateDisableDeciders(String logName) {
     List<String> disableDeciderList = new ArrayList<>();
     for (int i = SingerUtils.HOSTNAME_PREFIXES.size() - 1; i >= 0; i--) {
-      String convertedHostname = SingerUtils.HOSTNAME_PREFIXES.get(i).replace("-", "_");
+      String convertedHostname = SingerUtils.HOSTNAME_PREFIXES.get(i).replaceAll("[^a-zA-Z0-9]", "_");
       disableDeciderList.add("singer_disable_" + logName.replaceAll("[^a-zA-Z0-9]", "_") + "___" + convertedHostname + "___decider");
     }
     return disableDeciderList;

--- a/singer/src/main/java/com/pinterest/singer/config/Decider.java
+++ b/singer/src/main/java/com/pinterest/singer/config/Decider.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -110,30 +111,19 @@ public class Decider {
   }
 
   /***
-   * Given a log name, return the decider name that is used to disable the log. The disable decider
+   * Given a log name, return a list of possible decider names used to disable the log. The disable decider
    * name is required to be in the format of "singer_disable_logName___HOSTNAMEPREFIX___decider".
-   * Additionally, if there are multiple deciders that match this format , the one with the largest
-   * character count will be returned.
    *
    * @param logName
-   * @return the disable decider name if it exists, null otherwise
+   * @return a list of disable deciders
    */
-  public String getDisableDecider(String logName) {
-    Set<String> disableDeciderList = new HashSet<>();
-    String deciderName = null;
-    for (String key : mDeciderMap.keySet()) {
-      if (key.startsWith("singer_disable_" + logName + "___")) {
-        disableDeciderList.add(key);
-      }
+  public List<String> generateDisableDeciders(String logName) {
+    List<String> disableDeciderList = new ArrayList<>();
+    for (int i = SingerUtils.HOSTNAME_PREFIXES.size() - 1; i >= 0; i--) {
+      String convertedHostname = SingerUtils.HOSTNAME_PREFIXES.get(i).replace("-", "_");
+      disableDeciderList.add("singer_disable_" + logName.replaceAll("[^a-zA-Z0-9]", "_") + "___" + convertedHostname + "___decider");
     }
-    String convertedHostname = SingerUtils.HOSTNAME.replace("-", "_");
-    for (String decider : disableDeciderList) {
-      if (convertedHostname.startsWith(decider.split("___")[1])) {
-        deciderName =
-            deciderName != null && deciderName.length() > decider.length() ? deciderName : decider;
-      }
-    }
-    return deciderName;
+    return disableDeciderList;
   }
 
   /**

--- a/singer/src/main/java/com/pinterest/singer/config/Decider.java
+++ b/singer/src/main/java/com/pinterest/singer/config/Decider.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.config;
 
 import com.pinterest.singer.utils.HashUtils;
+import com.pinterest.singer.utils.SingerUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -101,6 +102,11 @@ public class Decider {
   @VisibleForTesting
   public Map<String, Integer> getDeciderMap() {
     return mDeciderMap;
+  }
+
+  public static String generateDisableDecider(String logName) {
+    return "singer_disable_" + logName + "___"
+        + SingerUtils.getHostnamePrefix().replace('-', '_') + "___decider";
   }
 
   /**

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -248,7 +248,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
   /**
    * If the decider is not set, this method will return true.
    * If a decider is set, return false when the decider's value is 0
-   * and disable decider's (if exists) value is 100.
+   * or disable decider's (if exists) value is 100.
    *
    * @return true or false.
    */

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -68,7 +68,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
   // Decider for the log stream.
   private final String logDecider;
 
-  // Valid deciders tha can be used in conjunction with logDecider to disable the logstream at a fleet level
+  // Valid deciders that can be used in conjunction with logDecider to disable the logstream at a fleet level
   private final List<String> disableDeciders;
 
   // LogStream to be processed.
@@ -247,8 +247,8 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
 
   /**
    * If the decider is not set, this method will return true.
-   * If a decider is set, return false when the decider's value is 0 or when the
-   * decider's value is != 0 and disable decider's (if exists) value is 100.
+   * If a decider is set, return false when the decider's value is 0
+   * and disable decider's (if exists) value is 100.
    *
    * @return true or false.
    */

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -265,7 +265,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
             LOG.info("Disabling log stream {} because fleet disable decider {} is set to 100",
                 logStream.getLogStreamName(), disableDecider);
             OpenTsdbMetricConverter.gauge(
-                "singer.processor.disable_decider_active", 1, "log=" + logStream.getSingerLog().getLogName());
+                SingerMetrics.DISABLE_DECIDER_ACTIVE, 1, "log=" + logStream.getSingerLog().getLogName());
             result = false;
             break;
           }

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -68,7 +68,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
   // Decider for the log stream.
   private final String logDecider;
 
-  // Decider used in conjunction with logDecider to disable the logstream at a fleet level
+  // Valid deciders tha can be used in conjunction with logDecider to disable the logstream at a fleet level
   private final List<String> disableDeciders;
 
   // LogStream to be processed.
@@ -247,8 +247,8 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
 
   /**
    * If the decider is not set, this method will return true.
-   * If a decider is set, only return false when the decider's value is 0 and disable decider's
-   * (if exists) value is 100.
+   * If a decider is set, return false when the decider's value is 0 or when the
+   * decider's value is != 0 and disable decider's (if exists) value is 100.
    *
    * @return true or false.
    */
@@ -264,6 +264,8 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
           if (map.containsKey(disableDecider) && map.get(disableDecider) == 100) {
             LOG.info("Disabling log stream {} because fleet disable decider {} is set to 100",
                 logStream.getLogStreamName(), disableDecider);
+            OpenTsdbMetricConverter.gauge(
+                "singer.processor.disable_decider_active", 1, "log=" + logStream.getSingerLog().getLogName());
             result = false;
             break;
           }

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -78,7 +78,7 @@ public class SingerUtils {
 
   public static final FileSystem defaultFileSystem = FileSystems.getDefault();
   public static String HOSTNAME = getHostname();
-  public static List<String> HOSTNAME_PREFIXES = getHostnamePrefixes();
+  public static List<String> HOSTNAME_PREFIXES = getHostnamePrefixes("-");
 
   public static String getHostname() {
     String hostName;
@@ -96,15 +96,15 @@ public class SingerUtils {
   }
 
   /***
-   * Gradually builds substrings from hostname separated by dashes
-   * will return hostname if hostname does not contain dashes
+   * Gradually builds substrings from hostname separated by a given regex,
+   * will return hostname if hostname can't be split by regex
    *
    * @param
    * @return a list of hostname prefixes
    */
-  public static List<String> getHostnamePrefixes() {
+  public static List<String> getHostnamePrefixes(String regex) {
     List<String> hostPrefixes = new ArrayList<>();
-    String [] splitHostname = HOSTNAME.split("-");
+    String [] splitHostname = HOSTNAME.split(regex);
     StringBuilder currentPrefix = new StringBuilder();
     for (String prefix : splitHostname) {
       currentPrefix.append(prefix);
@@ -253,6 +253,7 @@ public class SingerUtils {
     }
 
     LOG.info("Singer config loaded : " + singerConfig);
+    HOSTNAME_PREFIXES = getHostnamePrefixes(singerConfig.getHostnamePrefixRegex());
     return singerConfig;
   }
   
@@ -367,9 +368,9 @@ public class SingerUtils {
     }
   }
   @VisibleForTesting
-  public static void setHostname(String hostname) {
+  public static void setHostname(String hostname, String regex) {
     HOSTNAME = hostname;
-    HOSTNAME_PREFIXES = getHostnamePrefixes();
+    HOSTNAME_PREFIXES = getHostnamePrefixes(regex);
   }
 
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -96,13 +96,16 @@ public class SingerUtils {
   }
 
   /***
-   * Gradually builds substrings from hostname separated by a given regex,
+   * Gradually builds substrings separated by dashes from hostname given a regex,
    * will return hostname if hostname can't be split by regex
    *
    * @param
    * @return a list of hostname prefixes
    */
   public static List<String> getHostnamePrefixes(String regex) {
+    if (regex == null || regex.isEmpty()) {
+      return Arrays.asList(HOSTNAME);
+    }
     List<String> hostPrefixes = new ArrayList<>();
     String [] splitHostname = HOSTNAME.split(regex);
     StringBuilder currentPrefix = new StringBuilder();

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.comparator.LastModifiedFileComparator;
 import org.apache.commons.io.comparator.NameFileComparator;
@@ -89,23 +90,6 @@ public class SingerUtils {
       hostName = System.getenv("HOSTNAME");
     }
     return hostName;
-  }
-
-  /**
-   * @return the prefix of the host name
-   */
-  public static String getHostnamePrefix() {
-    String hostNameStringPrefix = "null";
-    if (HOSTNAME != null) {
-      String hostNameToSplit = "";
-      String[] substrs = HOSTNAME.split("\\d+");
-      if (substrs.length > 0) {
-        hostNameToSplit = substrs[0];
-      }
-      int dashIndex = hostNameToSplit.lastIndexOf('-');
-      hostNameStringPrefix = dashIndex == -1 ? hostNameToSplit : hostNameToSplit.substring(0, dashIndex);
-    }
-    return hostNameStringPrefix;
   }
 
   public static Path getPath(String filePathStr) {
@@ -359,6 +343,10 @@ public class SingerUtils {
         file.delete();
       }
     }
+  }
+  @VisibleForTesting
+  public static void setHostname(String hostname) {
+    HOSTNAME = hostname;
   }
   
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -34,9 +34,11 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.configuration.ConfigurationException;
@@ -76,6 +78,7 @@ public class SingerUtils {
 
   public static final FileSystem defaultFileSystem = FileSystems.getDefault();
   public static String HOSTNAME = getHostname();
+  public static List<String> HOSTNAME_PREFIXES = getHostnamePrefixes();
 
   public static String getHostname() {
     String hostName;
@@ -90,6 +93,25 @@ public class SingerUtils {
       hostName = System.getenv("HOSTNAME");
     }
     return hostName;
+  }
+
+  /***
+   * Gradually builds substrings from hostname separated by dashes
+   * will return hostname if hostname does not contain dashes
+   *
+   * @param
+   * @return a list of hostname prefixes
+   */
+  public static List<String> getHostnamePrefixes() {
+    List<String> hostPrefixes = new ArrayList<>();
+    String [] splitHostname = HOSTNAME.split("-");
+    StringBuilder currentPrefix = new StringBuilder();
+    for (String prefix : splitHostname) {
+      currentPrefix.append(prefix);
+      hostPrefixes.add(currentPrefix.toString());
+      currentPrefix.append("-");
+    }
+    return hostPrefixes;
   }
 
   public static Path getPath(String filePathStr) {
@@ -347,6 +369,7 @@ public class SingerUtils {
   @VisibleForTesting
   public static void setHostname(String hostname) {
     HOSTNAME = hostname;
+    HOSTNAME_PREFIXES = getHostnamePrefixes();
   }
-  
+
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -91,6 +91,23 @@ public class SingerUtils {
     return hostName;
   }
 
+  /**
+   * @return the prefix of the host name
+   */
+  public static String getHostnamePrefix() {
+    String hostNameStringPrefix = "null";
+    if (HOSTNAME != null) {
+      String hostNameToSplit = "";
+      String[] substrs = HOSTNAME.split("\\d+");
+      if (substrs.length > 0) {
+        hostNameToSplit = substrs[0];
+      }
+      int dashIndex = hostNameToSplit.lastIndexOf('-');
+      hostNameStringPrefix = dashIndex == -1 ? hostNameToSplit : hostNameToSplit.substring(0, dashIndex);
+    }
+    return hostNameStringPrefix;
+  }
+
   public static Path getPath(String filePathStr) {
     return defaultFileSystem.getPath(filePathStr);
   }

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -312,7 +312,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
   @Test
   public void testDisableDecider() throws Exception {
     DefaultLogStreamProcessor processor = null;
-    SingerUtils.setHostname("localhost-19970722");
+    SingerUtils.setHostname("localhost-prod.cluster-19970722", "[.-]");
     try {
       SingerConfig singerConfig = new SingerConfig();
       singerConfig.setThreadPoolSize(1);
@@ -338,7 +338,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
       assertEquals(false, processor.isLoggingAllowedByDecider());
 
       Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost___decider", 50);
-      Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost_19970722___decider", 100);
+      Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost_prod_cluster___decider", 100);
       assertEquals(false, processor.isLoggingAllowedByDecider());
 
     } catch (Exception e) {
@@ -349,7 +349,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
         processor.close();
       }
     }
-    SingerUtils.setHostname(SingerUtils.getHostname());
+    SingerUtils.setHostname(SingerUtils.getHostname(), "-");
   }
   private static List<LogMessage> getMessages(List<LogMessageAndPosition> messageAndPositions) {
     List<LogMessage> messages = Lists.newArrayListWithExpectedSize(messageAndPositions.size());

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -312,7 +312,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
   @Test
   public void testDisableDecider() throws Exception {
     DefaultLogStreamProcessor processor = null;
-    SingerUtils.setHostname("localhost");
+    SingerUtils.setHostname("localhost-19970722");
     try {
       SingerConfig singerConfig = new SingerConfig();
       singerConfig.setThreadPoolSize(1);
@@ -338,7 +338,8 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
       assertEquals(false, processor.isLoggingAllowedByDecider());
 
       Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost___decider", 50);
-      assertEquals(true, processor.isLoggingAllowedByDecider());
+      Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost_19970722___decider", 100);
+      assertEquals(false, processor.isLoggingAllowedByDecider());
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -349,6 +349,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
         processor.close();
       }
     }
+    SingerUtils.setHostname(SingerUtils.getHostname());
   }
   private static List<LogMessage> getMessages(List<LogMessageAndPosition> messageAndPositions) {
     List<LogMessage> messages = Lists.newArrayListWithExpectedSize(messageAndPositions.size());

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -37,6 +37,7 @@ import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
 import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
 import com.pinterest.singer.utils.SimpleThriftLogger;
+import com.pinterest.singer.utils.SingerUtils;
 import com.pinterest.singer.utils.WatermarkUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,6 +48,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.File;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTestBase {
@@ -307,6 +309,46 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
     }
   }
 
+  @Test
+  public void testDisableDecider() throws Exception {
+    DefaultLogStreamProcessor processor = null;
+    SingerUtils.setHostname("localhost");
+    try {
+      SingerConfig singerConfig = new SingerConfig();
+      singerConfig.setThreadPoolSize(1);
+      singerConfig.setWriterThreadPoolSize(1);
+      SingerSettings.initialize(singerConfig);
+      SingerLog singerLog = new SingerLog(
+          new SingerLogConfig("test", getTempPath(), "thrift.log", null, null, null));
+      LogStream logStream = new LogStream(singerLog, "thrift.log");
+      NoOpLogStreamWriter writer = new NoOpLogStreamWriter();
+      processor = new DefaultLogStreamProcessor(
+          logStream,
+          "singer_test_decider",
+          new DefaultLogStreamReader(
+              logStream,
+              new ThriftLogFileReaderFactory(new ThriftReaderConfig(16000, 16000))),
+          writer,
+          50, 1, 1, 3600, 1800);
+      Decider.setInstance(new HashMap<>());
+      Decider.getInstance().getDeciderMap().put("singer_test_decider", 100);
+      assertEquals(true, processor.isLoggingAllowedByDecider());
+
+      Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost___decider", 100);
+      assertEquals(false, processor.isLoggingAllowedByDecider());
+
+      Decider.getInstance().getDeciderMap().put("singer_disable_test___localhost___decider", 50);
+      assertEquals(true, processor.isLoggingAllowedByDecider());
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("Unexpected exception");
+    } finally {
+      if (processor != null) {
+        processor.close();
+      }
+    }
+  }
   private static List<LogMessage> getMessages(List<LogMessageAndPosition> messageAndPositions) {
     List<LogMessage> messages = Lists.newArrayListWithExpectedSize(messageAndPositions.size());
     for (LogMessageAndPosition messageAndPosition : messageAndPositions) {

--- a/singer/src/test/java/com/pinterest/singer/utils/TestSingerUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestSingerUtils.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -24,6 +25,8 @@ import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.monitor.LogStreamManager;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+
+import java.util.List;
 
 public class TestSingerUtils {
 
@@ -51,6 +54,47 @@ public class TestSingerUtils {
     logStream = new LogStream(new SingerLog(new SingerLogConfig(), "pod-11"), "test");
     hostNameBasedOnConfig = SingerUtils.getHostNameBasedOnConfig(logStream, config);
     assertEquals(SingerUtils.getHostname(), hostNameBasedOnConfig);
+  }
+
+  @Test
+  public void testGetHostnamePrefixes() {
+    // Check simple dashes only
+    String regex = "-";
+    SingerUtils.setHostname("localhost-prod-cluster-19970722", regex);
+    String [] prefixes = {"localhost", "localhost-prod", "localhost-prod-cluster", "localhost-prod-cluster-19970722"};
+    List<String> finalPrefixes = SingerUtils.getHostnamePrefixes(regex);
+    assertTrue(finalPrefixes.equals(java.util.Arrays.asList(prefixes)));
+    
+    // Check dots and dashes
+    regex = "[.-]";
+    SingerUtils.setHostname("localhost-prod.cluster-19970722", regex);
+    prefixes = new String[]{"localhost", "localhost-prod", "localhost-prod-cluster", "localhost-prod-cluster-19970722"};
+    finalPrefixes = SingerUtils.getHostnamePrefixes(regex);
+    assertTrue(finalPrefixes.equals(java.util.Arrays.asList(prefixes)));
+
+    // Check regex is empty
+    regex = "";
+    SingerUtils.setHostname("localhost-dev.19970722", regex);
+    prefixes = new String []{"localhost-dev.19970722"};
+    finalPrefixes = SingerUtils.getHostnamePrefixes(regex);
+    assertTrue(finalPrefixes.equals(java.util.Arrays.asList(prefixes)));
+
+    // Check regex is null
+    regex = null;
+    SingerUtils.setHostname("localhost-dev.19970722", regex);
+    prefixes = new String []{"localhost-dev.19970722"};
+    finalPrefixes = SingerUtils.getHostnamePrefixes(regex);
+    assertTrue(finalPrefixes.equals(java.util.Arrays.asList(prefixes)));
+
+    // Check regex is not matched
+    regex = "abc";
+    SingerUtils.setHostname("localhost-dev.19970722", regex);
+    prefixes = new String []{"localhost-dev.19970722"};
+    finalPrefixes = SingerUtils.getHostnamePrefixes(regex);
+    assertTrue(finalPrefixes.equals(java.util.Arrays.asList(prefixes)));
+
+    // reset hostname
+    SingerUtils.setHostname(SingerUtils.getHostname(), "-");
   }
 
 }


### PR DESCRIPTION
Disable a logstream if fleet level disable decider is set to 100, otherwise continue with regular execution. This decider needs to be in the format: `singer_disable_<logstream_name>___<hostname_prefix>___decider` where all non non-alphanumeric charcters in `logstream_name` are replaced by underscores. Also introduce a utility function to retrieve hostname prefix list.