### PR TITLE
Fix ignore pod logic when flag is set to null or empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.78</version>
+    <version>0.8.0.79</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.78</version>
+    <version>0.8.0.79</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.78</version>
+        <version>0.8.0.79</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
@@ -450,6 +450,7 @@ public class KubeService implements Runnable {
     }
 
     private boolean checkIgnoreDirectory(String podName) {
+      if (ignorePodDirectory == null || ignorePodDirectory.isEmpty()) return false;
       return Files.exists(Paths.get(podLogDirectory, podName, ignorePodDirectory));
     }
 }

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.78</version>
+    <version>0.8.0.79</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
Return false from `checkIgnoreDirectory(String podName)` when ignorePodDirectory is empty or null