### PR TITLE
Initialize ostrich metrics service before main initialize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.80</version>
+    <version>0.8.0.81</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.80</version>
+    <version>0.8.0.81</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.80</version>
+        <version>0.8.0.81</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/SingerMain.java
+++ b/singer/src/main/java/com/pinterest/singer/SingerMain.java
@@ -162,8 +162,8 @@ public final class SingerMain {
         if (singerConfig.isHeartbeatEnabled()) {
           SingerSettings.heartbeatGenerator = new HeartbeatGenerator(singerConfig);
         }
-        SingerSettings.initialize(singerConfig);
         startOstrichService(singerConfig);
+        SingerSettings.initialize(singerConfig);
       }
     } catch (Throwable t) {
       LOG.error("Singer failed.", t);

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.80</version>
+    <version>0.8.0.81</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
When a log directory contains a large number of files, the initialization of all log streams in the directory can take some time for Singer after a restart. However, by initiating the metrics service prior to `SingerSettings.initialize()`, we can continue to publish metrics while Singer finalizes the log stream initialization process.