### PR TITLE
S3 Writer Test Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.85</version>
+    <version>0.8.0.86</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.85</version>
+    <version>0.8.0.86</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.85</version>
+        <version>0.8.0.86</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
@@ -309,7 +309,7 @@ public class S3Writer implements LogStreamWriter {
 
         String logName = logStream.getSingerLog().getSingerLogConfig().getName();
         List<String> hostPrefixes = getHostnamePrefixes("-");
-        String serviceFleet = hostPrefixes.get(hostPrefixes.size() - 2);
+        String serviceFleet = hostPrefixes.size() == 1 ? hostPrefixes.get(0) : hostPrefixes.get(hostPrefixes.size() - 2);
         String host = extractHostSuffix(HOSTNAME);
         String logDir = logStream.getFullPathPrefix().substring(1);
         String customFilename = s3WriterConfig.getFileNameFormat();

--- a/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
@@ -2,14 +2,14 @@ package com.pinterest.singer.writer;
 
 import com.pinterest.singer.SingerTestBase;
 import com.pinterest.singer.common.LogStream;
-import com.pinterest.singer.writer.s3.ObjectUploaderTask;
-import com.pinterest.singer.writer.s3.S3Writer;
-import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.LogMessageAndPosition;
 import com.pinterest.singer.thrift.configuration.S3WriterConfig;
-import com.pinterest.singer.common.SingerLog;
-
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+import com.pinterest.singer.utils.SingerUtils;
+import com.pinterest.singer.writer.s3.ObjectUploaderTask;
+import com.pinterest.singer.writer.s3.S3Writer;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.After;
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -48,6 +48,9 @@ public class S3WriterTest extends SingerTestBase {
 
     @Before
     public void setUp() {
+        // set hostname
+        SingerUtils.setHostname("localhost-dev", "-");
+
         // Initialize basics
         tempPath = getTempPath();
         String logStreamHeadFileName = "thrift.log";

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.85</version>
+    <version>0.8.0.86</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
# Changes
Make sure hostnames without a delimiter can still function correctly when naming AWS file format. Injecting the hostname for S3WriterTest for consistency.