### PR TITLE
Pool reader buffers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.86</version>
+    <version>0.8.0.87</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.86</version>
+    <version>0.8.0.87</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -439,4 +439,9 @@ struct SingerConfig {
    */
   28: optional string hostnamePrefixRegex = "-";
 
+  /**
+  * Initialize LogStreamReaders with pooled buffers
+  */
+  29: optional bool enablePooledReaderBuffers = false;
+
 }

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -4,6 +4,9 @@
     <packaging>jar</packaging>
     <description>Logging Agent</description>
     <inceptionYear>2013</inceptionYear>
+    <properties>
+        <netty.version>4.1.75.Final</netty.version>
+    </properties>
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
@@ -86,6 +89,11 @@
                     <artifactId>slf4j-jdk14</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.86</version>
+        <version>0.8.0.87</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
@@ -58,6 +58,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.twitter.ostrich.stats.Stats;
+import io.netty.buffer.PoolArenaMetric;
+import io.netty.buffer.PooledByteBufAllocator;
 import org.apache.commons.configuration.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -558,6 +560,15 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
     Map<String, List<Long>> perLogLatency = Maps.newHashMap();
     Map<String, Integer> perLogStuck = Maps.newHashMap();
     DefaultLogStreamProcessor processor;
+
+    OpenTsdbMetricConverter.gauge("singer.netty_heap_buffer.memory.used",
+        PooledByteBufAllocator.DEFAULT.metric().usedHeapMemory());
+    OpenTsdbMetricConverter.gauge("singer.netty_heap_buffer.active.allocation.bytes", PooledByteBufAllocator.DEFAULT.metric().heapArenas().stream()
+        .mapToLong(PoolArenaMetric::numActiveBytes).sum());
+    OpenTsdbMetricConverter.gauge("singer.netty_direct_buffer.memory.used",
+        PooledByteBufAllocator.DEFAULT.metric().usedDirectMemory());
+    OpenTsdbMetricConverter.gauge("singer.netty_direct_buffer.active.allocation.bytes", PooledByteBufAllocator.DEFAULT.metric().directArenas().stream()
+        .mapToLong(PoolArenaMetric::numActiveBytes).sum());
 
     for (LogStream logStream : processedLogStreams.keySet()) {
       String logName = logStream.getSingerLog().getSingerLogConfig().getName();

--- a/singer/src/main/java/com/pinterest/singer/reader/ByteOffsetInputStream.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ByteOffsetInputStream.java
@@ -26,7 +26,7 @@ import java.io.RandomAccessFile;
  * The byteOffset will be from the beginning of the file.
  * Note that the file can be appended as it is being read.
  */
-public final class ByteOffsetInputStream extends BufferedInputStream {
+public final class ByteOffsetInputStream extends BufferedInputStream implements OffsetInputStream {
 
   private final RandomAccessFile randomAccessFile;
   // Byte offset of current read position.

--- a/singer/src/main/java/com/pinterest/singer/reader/OffsetInputStream.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/OffsetInputStream.java
@@ -1,0 +1,13 @@
+package com.pinterest.singer.reader;
+
+import java.io.IOException;
+
+/**
+ * Interface for InputStream that can track and set the byte offset for the next read.
+ * byteOffset will start from the beginning of the file.
+ */
+public interface OffsetInputStream {
+  long getByteOffset();
+  void setByteOffset(long byteOffset) throws IOException;
+  boolean isEOF() throws IOException;
+}

--- a/singer/src/main/java/com/pinterest/singer/reader/RandomAccessFileInputStream.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/RandomAccessFileInputStream.java
@@ -28,7 +28,7 @@ import java.io.RandomAccessFile;
  * This class will allow us to set the file pointer when we need to go back in the stream. It
  * also allow us to track the byte offset of the next thrift message by reading the file pointer.
  */
-final class RandomAccessFileInputStream extends InputStream {
+public final class RandomAccessFileInputStream extends InputStream {
 
   private final RandomAccessFile file;
 

--- a/singer/src/main/java/com/pinterest/singer/reader/pooled/PooledByteBufInputStream.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/pooled/PooledByteBufInputStream.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2024 Pinterest, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.singer.reader.pooled;
+
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.reader.OffsetInputStream;
+import com.pinterest.singer.reader.RandomAccessFileInputStream;
+
+import com.google.common.base.Preconditions;
+import io.netty.buffer.ByteBuf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+
+/**
+ * This is a BufferedInputStream like implementation that uses a Netty's Pooled ByteBuf instead.
+ * It can track and set the byte offset for the next read. The byteOffset will start from the
+ * beginning of the file. Note that the file can be appended as it is being read.Most of the methods
+ * in this class are based on ByteOffsetInputStream and BufferedInputStream.
+ */
+public class PooledByteBufInputStream extends InputStream implements OffsetInputStream {
+
+  private ByteBuf buffer;
+  private InputStream source;
+  private long byteOffset;
+  private final RandomAccessFile randomAccessFile;
+
+  public PooledByteBufInputStream(RandomAccessFile randomAccessFile, ByteBuf byteBuf) {
+    source = new RandomAccessFileInputStream(Preconditions.checkNotNull(randomAccessFile));
+    buffer = Preconditions.checkNotNull(byteBuf);
+    OpenTsdbMetricConverter.incr("singer.reader.pooled.create_buffer");
+    this.randomAccessFile = randomAccessFile;
+    byteOffset = 0;
+  }
+
+  /**
+   * Reads a single byte from the buffer. If the buffer is empty, it will refill the buffer.
+   *
+   * @return the byte read or -1 if the end of the stream has been reached.
+   * @throws IOException
+   */
+  @Override
+  public synchronized int read() throws IOException {
+    if(!buffer.isReadable()) {
+      refillBuffer();
+    }
+    return buffer.isReadable() ? buffer.readByte() & 0xFF : -1;
+  }
+
+  /**
+   * Refills the buffer with data from the source.
+   *
+   * @throws IOException
+   */
+  private void refillBuffer() throws IOException {
+    buffer.clear();
+    int bytesToTransfer = buffer.capacity();
+    // read directly from the source into buffer with writeBytes to avoid extra copy
+    buffer.writeBytes(source, bytesToTransfer);
+  }
+
+  /**
+   * Basic method to read data into a byte array. It will attempt
+   * to read from the buffer first and then from the source if necessary.
+   *
+   * @param b     destination buffer
+   * @param off   the start offset in array <code>b</code>
+   *                   at which the data is written.
+   * @param len   the maximum number of bytes to read.
+   * @return The total number of bytes read.
+   * @throws IOException
+   */
+  @Override
+  public synchronized int read(byte b[], int off, int len) throws IOException {
+    int bytesRead = readIntoBuffer(b, off, len);
+    byteOffset += Math.max(0, bytesRead);
+    return bytesRead;
+  }
+
+  /**
+   * Reads data from the buffer or source until the number of bytes requested is read or
+   * the end of the stream is reached. This method repeatedly calls readAndFill until either
+   * of the conditions are met.
+   *
+   * @param b destination buffer
+   * @param off the start offset in array <code>b</code> at which the data is written.
+   * @param len
+   * @return
+   * @throws IOException
+   */
+  private synchronized int readIntoBuffer(byte b[], int off, int len) throws IOException {
+    if (b == null) {
+      throw new NullPointerException();
+    } else if (off < 0 || len < 0 || len > b.length - off) {
+      throw new IndexOutOfBoundsException();
+    } else if (len == 0) {
+      return 0;
+    }
+
+    // Read until we read the number of bytes requested or until we run out of bytes to read.
+    int totalBytesRead = 0;
+    while (true) {
+      int bytesRead = readAndFill(b, off + totalBytesRead, len - totalBytesRead);
+      if (bytesRead <= 0)
+        return (totalBytesRead == 0) ? bytesRead : totalBytesRead;
+      totalBytesRead += bytesRead;
+      if (totalBytesRead >= len)
+        return totalBytesRead;
+      // Return if there are no more available bytes in the source.
+      if (source != null && source.available() <= 0)
+        return totalBytesRead;
+    }
+  }
+
+  /**
+   * Reads data from the buffer into a byte array and refills
+   * the buffer from the source if necessary.
+   *
+   * @param b destination buffer
+   * @param off the start offset in array <code>b</code at which the data is written.
+   * @param len length of the data to read
+   * @return the number of bytes read
+   * @throws IOException
+   */
+  private int readAndFill(byte[] b, int off, int len) throws IOException {
+    int avail = buffer.readableBytes();
+    if (avail <= 0) {
+      // Read directly from the source if the length is greater than the buffer capacity.
+      if (len >= buffer.capacity()) {
+        return source.read(b, off, len);
+      }
+      refillBuffer();
+      avail = buffer.readableBytes();
+      if (avail <= 0) return -1;
+    }
+    int cnt = (avail < len) ? avail : len;
+    buffer.getBytes(buffer.readerIndex(), b, off, cnt);
+    buffer.readerIndex(buffer.readerIndex() + cnt);
+    return cnt;
+  }
+
+  /**
+   * Reads directly from source.
+   *
+   * @param buffer destination buffer
+   * @return number of bytes read
+   * @throws IOException
+   */
+  @Override
+  public int read(byte[] buffer) throws IOException {
+    return source.read(buffer);
+  }
+
+  /**
+   * Get the byte offset for the next read.
+   */
+  public long getByteOffset() {
+    return byteOffset;
+  }
+
+  /**
+   * Set the byte offset for the next read.
+   */
+  public void setByteOffset(long byteOffset) throws IOException {
+    // Clear the buffer
+    buffer.readerIndex(buffer.writerIndex());
+    // Set file byte offset
+    randomAccessFile.seek(byteOffset);
+    // Set stream byte offset.
+    this.byteOffset = byteOffset;
+  }
+
+  /**
+   * Checks if the stream is at the end of the file.
+   *
+   * @return true if the stream is at the end of the file.
+   * @throws IOException
+   */
+  public boolean isEOF() throws IOException {
+    // If buffer is not empty, we are not at end of stream.
+    if (buffer.readerIndex() != buffer.writerIndex()) {
+      return false;
+    }
+    // Try read one byte from the file.
+    long currentFilePointer = randomAccessFile.getFilePointer();
+    if (randomAccessFile.read() == -1) {
+      // We can not read one byte. File pointer will not be moved by the read. Just return true.
+      return true;
+    } else {
+      // We can read one byte. Move file pointer back and return false.
+      randomAccessFile.seek(currentFilePointer);
+      return false;
+    }
+  }
+
+
+  /**
+   * Skips over and discards n bytes of data from the input stream. In addition, it
+   * will not skip more bytes than the number of bytes available in the buffer.
+   *
+   * @param n the number of bytes to be skipped.
+   * @return number of bytes skipped
+   * @throws IOException
+   */
+  @Override
+  public long skip(long n) throws IOException {
+    // We pose a limit on the number of bytes that can be skipped since
+    // the ByteBuf methods can only take integers.
+    if (!(Integer.MIN_VALUE <= n && n <= Integer.MAX_VALUE)) {
+      throw new IllegalArgumentException("Skip value is too large");
+    }
+
+    long bytesSkipped = 0;
+    if (n <= 0) {
+      return 0;
+    }
+    int readableBytes = buffer.readableBytes();
+    if (readableBytes <= 0) {
+      refillBuffer();
+      readableBytes = buffer.readableBytes();
+    }
+    bytesSkipped = (readableBytes < n) ? readableBytes : n;
+    // Skip bytes by moving the reader index.
+    buffer.readerIndex((int) bytesSkipped);
+    byteOffset += bytesSkipped;
+    return bytesSkipped;
+  }
+
+  /**
+   * Closes the stream and releases the buffer.
+   *
+   * @throws IOException
+   */
+  @Override
+  public void close() throws IOException {
+    source.close();
+    buffer.release();
+    OpenTsdbMetricConverter.incr("singer.reader.pooled.close_buffer");
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -715,6 +715,9 @@ public class LogConfigUtils {
     if (singerConfiguration.containsKey("fsEventQueueImplementation")) {
       singerConfig.setFsEventQueueImplementation(singerConfiguration.getString("fsEventQueueImplementation"));
     }
+    if (singerConfiguration.containsKey("enablePooledReaderBuffers")) {
+      singerConfig.setEnablePooledReaderBuffers(singerConfiguration.getBoolean("enablePooledReaderBuffers"));
+    }
     return singerConfig;
   }
 

--- a/singer/src/test/java/com/pinterest/singer/reader/ThriftLogFileReaderTest.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/ThriftLogFileReaderTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertThat;
 import com.pinterest.singer.SingerTestBase;
 import com.pinterest.singer.common.LogStream;
 import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.LogMessageAndPosition;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
 import com.pinterest.singer.utils.SimpleThriftLogger;
 
@@ -42,6 +44,9 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
 
   @Test
   public void testReadBadMessage() throws Exception {
+    SingerConfig singerConfig = new SingerConfig();
+    singerConfig.setEnablePooledReaderBuffers(true);
+    SingerSettings.setSingerConfig(singerConfig);
     String path = FilenameUtils.concat(getTempPath(), "thrift.log");
 
     SimpleThriftLogger<LogMessage> logger = new SimpleThriftLogger<>(path);
@@ -75,6 +80,9 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
 
   @Test
   public void testReadLogMessageAndPosition() throws Exception {
+    SingerConfig singerConfig = new SingerConfig();
+    singerConfig.setEnablePooledReaderBuffers(true);
+    SingerSettings.setSingerConfig(singerConfig);
     String path = FilenameUtils.concat(getTempPath(), "thrift.log");
 
     SimpleThriftLogger<LogMessage> logger = new SimpleThriftLogger<>(path);
@@ -127,10 +135,21 @@ public class ThriftLogFileReaderTest extends SingerTestBase {
     }
 
     // Return null when no more message in the log file.
+    for (int i = 0; i < messagesWritten.size(); i++) {
+      LogMessageAndPosition written = messagesWritten.get(i);
+      LogMessageAndPosition read = messagesRead.get(i);
+      assertThat(written.getLogMessage(), is(read.getLogMessage()));
+      assertThat(written.getNextPosition().getByteOffset(), is(read.getNextPosition().getByteOffset()));
+    }
+
+    // Return null when no more message in the log file.
     assertThat(messagesRead, is(messagesWritten));
   }
 
   public void testEnvironmentVariableInjection() throws Exception {
+    SingerConfig singerConfig = new SingerConfig();
+    singerConfig.setEnablePooledReaderBuffers(true);
+    SingerSettings.setSingerConfig(singerConfig);
     String path = FilenameUtils.concat(getTempPath(), "thrift.log");
     SimpleThriftLogger<LogMessage> logger = new SimpleThriftLogger<>(path);
     List<LogMessageAndPosition> messagesWritten;

--- a/singer/src/test/java/com/pinterest/singer/reader/pooled/PooledByteBufInputStreamTest.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/pooled/PooledByteBufInputStreamTest.java
@@ -1,0 +1,80 @@
+package com.pinterest.singer.reader.pooled;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.pinterest.singer.utils.SingerUtils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PooledByteBufInputStreamTest {
+
+  public final static String TEST_DIR = "target/pooled_tests";
+
+  @After
+  public void after() throws Exception {
+    File baseDir = new File(TEST_DIR);
+    SingerUtils.deleteRecursively(baseDir);
+    Files.delete(baseDir.toPath());
+  }
+
+  @Test
+  public void testBuffersAreClosed() throws Exception {
+    File testDir = new File(TEST_DIR);
+    testDir.mkdirs();
+    int bufferCount = 10;
+    List<ByteBuf> buffers = new ArrayList<>();
+    List<PooledByteBufInputStream> inputStreams = new ArrayList<>();
+
+    for (int i = 0; i < bufferCount; i++) {
+      File file = new File(TEST_DIR + "/test" + i);
+      file.createNewFile();
+      ByteBuf buffer = PooledByteBufAllocator.DEFAULT.buffer(1024, 1024);
+      buffers.add(buffer);
+      PooledByteBufInputStream
+          inputStream =
+          new PooledByteBufInputStream(new RandomAccessFile(file.getPath(), "r"), buffer);
+      inputStreams.add(inputStream);
+    }
+
+    assertEquals(bufferCount, buffers.size());
+
+    for (PooledByteBufInputStream inputStream : inputStreams) {
+      inputStream.close();
+    }
+
+    int refCnt = 0;
+    for (ByteBuf buffer : buffers) {
+      refCnt += buffer.refCnt();
+    }
+    assertEquals(0, refCnt);
+  }
+
+  @Test
+  public void testSimpleReadIntoBufferEOF() throws Exception {
+    File testDir = new File(TEST_DIR);
+    testDir.mkdirs();
+    File testFile = new File(testDir + "/test");
+    testFile.createNewFile();
+
+    String value = "This is a simple read test";
+    byte[] bytes = value.getBytes();
+    Files.write(testFile.toPath(), bytes);
+    RandomAccessFile file = new RandomAccessFile(testFile.getPath(), "r");
+    PooledByteBufInputStream pooledByteBufInputStream = new PooledByteBufInputStream(file, PooledByteBufAllocator.DEFAULT.directBuffer(1024, 1024));
+    byte[] buffer = new byte[1024];
+    int read = pooledByteBufInputStream.read(buffer, 0, value.length());
+    assertEquals(value.length(), read);
+    assertEquals(value, new String(buffer, 0, read));
+    assertTrue(pooledByteBufInputStream.isEOF());
+  }
+}

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.86</version>
+    <version>0.8.0.87</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
This PR introduces a buffered input stream implementation that leverages Netty's pooled direct `ByteBuf` for buffering, instead of traditional nio ByteBuffers or byte arrays. This approach aims to minimize garbage collection overhead by reusing pooled buffers rather than repeatedly creating new ones for each stream. This optimization is particularly useful for scenarios where a single Singer instance handles thousands of log streams.