### PR TITLE
Refactor S3Writer class to improve code structure

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
@@ -25,6 +25,14 @@ public class ObjectUploaderTask {
         this.maxRetries = maxRetries;
     }
 
+    /**
+     * Uploads a file to S3 using the PutObject API.
+     * Uses exponential backoff with a cap for retries.
+     *
+     * @param file is the actual file in disk to be uploaded
+     * @param fileFormat is the key suffix
+     * @return true if the file was successfully uploaded, false otherwise
+     */
     public boolean upload(File file, String fileFormat) {
         int attempts = 0;
         boolean success = false;

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
@@ -1,6 +1,7 @@
 package com.pinterest.singer.writer.s3;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import com.pinterest.singer.common.LogStream;
 import com.pinterest.singer.common.LogStreamWriter;
 import com.pinterest.singer.common.SingerMetrics;
@@ -38,185 +39,189 @@ import static com.pinterest.singer.utils.SingerUtils.getHostnamePrefixes;
  * A LogStreamWriter for Singer that writes to S3 (writer.type=s3).
  * */
 public class S3Writer implements LogStreamWriter {
-    private static final String HOSTNAME = SingerUtils.HOSTNAME;
-    private static final Logger LOG = LoggerFactory.getLogger(S3Writer.class);
-    private static final SimpleDateFormat FORMATTER = new SimpleDateFormat("yyyyMMddHHmmssSSS");
-    private final LogStream logStream;
-    private final String logName;
-    private final String BUFFER_DIR;
-    private static final int BYTES_IN_MB = 1024 * 1024;
-    private ObjectUploaderTask putObjectUploader;
-    private S3Client s3Client;
-    private final S3WriterConfig s3WriterConfig;
 
-    // S3 information
-    private String bucketName;
-    private String keyPrefix;
+  private static final String HOSTNAME = SingerUtils.HOSTNAME;
+  private static final Logger LOG = LoggerFactory.getLogger(S3Writer.class);
+  private static final SimpleDateFormat FORMATTER = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+  private final LogStream logStream;
+  private final String logName;
+  private final String BUFFER_DIR;
+  private static final int BYTES_IN_MB = 1024 * 1024;
+  private ObjectUploaderTask putObjectUploader;
+  private S3Client s3Client;
+  private final S3WriterConfig s3WriterConfig;
 
-    // Disk-buffered file that will eventually be uploaded to S3 if size or time thresholds are met
-    private BufferedOutputStream bufferedOutputStream;
-    private File bufferFile;
+  // S3 information
+  private String bucketName;
+  private String keyPrefix;
 
-    // Custom Thresholds
-    private int maxFileSizeMB;
-    private int minUploadTime;
-    private int maxRetries;
+  // Disk-buffered file that will eventually be uploaded to S3 if size or time thresholds are met
+  private BufferedOutputStream bufferedOutputStream;
+  private File bufferFile;
 
-    // Timer for scheduling uploads
-    private static ScheduledExecutorService fileUploadTimer;
-    private Future<?> uploadFuture;
-    private final Object objLock = new Object(); // used for synchronization locking
-    static {
-        ScheduledThreadPoolExecutor tmpTimer = new ScheduledThreadPoolExecutor(1);
-        tmpTimer.setRemoveOnCancelPolicy(true);
-        fileUploadTimer = tmpTimer;
+  // Custom Thresholds
+  private int maxFileSizeMB;
+  private int minUploadTime;
+  private int maxRetries;
+
+  // Timer for scheduling uploads
+  private static ScheduledExecutorService fileUploadTimer;
+  private Future<?> uploadFuture;
+  private final Object objLock = new Object(); // used for synchronization locking
+
+  static {
+    ScheduledThreadPoolExecutor tmpTimer = new ScheduledThreadPoolExecutor(1);
+    tmpTimer.setRemoveOnCancelPolicy(true);
+    fileUploadTimer = tmpTimer;
+  }
+
+  /**
+   * Constructs an S3Writer instance.
+   *
+   * @param logStream the LogStream associated with this writer
+   * @param s3WriterConfig the S3WriterConfig containing configuration settings
+   */
+  public S3Writer(LogStream logStream, S3WriterConfig s3WriterConfig) {
+    Preconditions.checkNotNull(logStream);
+    Preconditions.checkNotNull(s3WriterConfig);
+
+    this.logStream = logStream;
+    this.logName = logStream.getSingerLog().getSingerLogConfig().getName();
+    this.s3WriterConfig = s3WriterConfig;
+    this.BUFFER_DIR = s3WriterConfig.getBufferDir();
+    initialize();
+  }
+
+  // Static factory method for testing
+  @VisibleForTesting
+  public S3Writer(LogStream logStream, S3WriterConfig s3WriterConfig, S3Client s3Client,
+                  ObjectUploaderTask putObjectUploader, String path) {
+    Preconditions.checkNotNull(logStream);
+    Preconditions.checkNotNull(s3WriterConfig);
+    Preconditions.checkNotNull(s3Client);
+    Preconditions.checkNotNull(putObjectUploader);
+    Preconditions.checkNotNull(!Strings.isNullOrEmpty(path));
+
+    this.BUFFER_DIR = path;
+    this.logStream = logStream;
+    this.logName = logStream.getSingerLog().getSingerLogConfig().getName();
+    this.s3WriterConfig = s3WriterConfig;
+    this.putObjectUploader = putObjectUploader;
+    this.s3Client = s3Client;
+    initialize();
+
+  }
+
+  private void initialize() {
+    this.maxFileSizeMB = s3WriterConfig.getMaxFileSizeMB();
+    this.minUploadTime = s3WriterConfig.getMinUploadTimeInSeconds();
+    this.maxRetries = s3WriterConfig.getMaxRetries();
+
+    // Create directory if it does not exist
+    new File(BUFFER_DIR).mkdirs();
+    try {
+      resetBufferFile();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create buffer file", e);
     }
 
-    /**
-     * Constructs an S3Writer instance.
-     *
-     * @param logStream the LogStream associated with this writer
-     * @param s3WriterConfig the S3WriterConfig containing configuration settings
-     */
-    public S3Writer(LogStream logStream, S3WriterConfig s3WriterConfig) {
-        Preconditions.checkNotNull(logStream);
-        Preconditions.checkNotNull(s3WriterConfig);
+    this.keyPrefix = s3WriterConfig.getKeyPrefix();
 
-        this.logStream = logStream;
-        this.logName = logStream.getSingerLog().getSingerLogConfig().getName();
-        this.s3WriterConfig = s3WriterConfig;
-        this.BUFFER_DIR = s3WriterConfig.getBufferDir();
-        initialize();
+    // Configure bucket name
+    this.bucketName = s3WriterConfig.getBucket();
+    if (this.bucketName == null) {
+      throw new RuntimeException("Bucket name is not configured");
     }
 
-    // Static factory method for testing
-    @VisibleForTesting
-    public S3Writer(LogStream logStream, S3WriterConfig s3WriterConfig, S3Client s3Client,
-                    ObjectUploaderTask putObjectUploader, String path) {
-      Preconditions.checkNotNull(logStream);
-      Preconditions.checkNotNull(s3WriterConfig);
-      Preconditions.checkNotNull(s3Client);
-      Preconditions.checkNotNull(putObjectUploader);
-      Preconditions.checkNotNull(!Strings.isNullOrEmpty(path));
-
-      this.BUFFER_DIR = path;
-      this.logStream = logStream;
-      this.logName = logStream.getSingerLog().getSingerLogConfig().getName();
-      this.s3WriterConfig = s3WriterConfig;
-      this.putObjectUploader = putObjectUploader;
-      this.s3Client = s3Client;
-      initialize();
-
+    try {
+      if (s3Client == null) {
+        s3Client = S3Client.builder().build();
+      }
+      if (putObjectUploader == null) {
+        putObjectUploader = new ObjectUploaderTask(s3Client, bucketName, keyPrefix, maxRetries);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    private void initialize() {
-        this.maxFileSizeMB = s3WriterConfig.getMaxFileSizeMB();
-        this.minUploadTime = s3WriterConfig.getMinUploadTimeInSeconds();
-        this.maxRetries = s3WriterConfig.getMaxRetries();
+  @Override
+  public LogStream getLogStream() {
+    return this.logStream;
+  }
 
-        // Create directory if it does not exist
-        new File(BUFFER_DIR).mkdirs();
+  @Override
+  public boolean isAuditingEnabled() {
+    return false;
+  }
+
+  @Override
+  public boolean isCommittableWriter() {
+    return true;
+  }
+
+  /**
+   * Takes the fullPathPrefix and removes all slashes and replaces them with underscores.
+   */
+  public static String sanitizeFileName(String fullPathPrefix) {
+    if (fullPathPrefix.startsWith("/")) {
+      fullPathPrefix = fullPathPrefix.substring(1);
+    }
+    return fullPathPrefix.replace("/", "_");
+  }
+
+  /**
+   * Starts the commit process, initializing the buffer file and scheduling an upload task if not
+   * already scheduled.
+   *
+   * @param isDraining whether the system is in a draining state
+   * @throws LogStreamWriterException if an error occurs while creating or writing to the buffer
+   * file
+   */
+  @Override
+  public synchronized void startCommit(boolean isDraining) throws LogStreamWriterException {
+    try {
+      if (!bufferFile.exists()) {
+        bufferFile.createNewFile();
+      }
+
+      bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
+
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create buffer file: " + bufferFile.getName(), e);
+    }
+    if (uploadFuture == null) {
+      scheduleUploadTask();
+    }
+  }
+
+
+  /**
+   * Schedules a task to upload the buffer file at regular intervals.
+   * If the buffer file exists and has data, it is renamed and a new buffer file is created.
+   * The renamed file is then uploaded to S3.
+   */
+  private void scheduleUploadTask() {
+    synchronized (objLock) {
+      if (uploadFuture != null && !uploadFuture.isDone()) {
+        LOG.info("An upload task is already scheduled or running");
+        return;
+      }
+      uploadFuture = fileUploadTimer.schedule(() -> {
         try {
-            resetBufferFile();
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create buffer file", e);
-        }
-
-        this.keyPrefix = s3WriterConfig.getKeyPrefix();
-
-        // Configure bucket name
-        this.bucketName = s3WriterConfig.getBucket();
-        if (this.bucketName == null) {
-            throw new RuntimeException("Bucket name is not configured");
-        }
-
-        try {
-            if (s3Client == null) {
-                s3Client = S3Client.builder().build();
+          synchronized (objLock) {
+            if (bufferFile.length() > 0) {
+              bufferedOutputStream.close();
+              uploadDiskBufferedFileToS3();
             }
-            if (putObjectUploader == null) {
-                putObjectUploader = new ObjectUploaderTask(s3Client, bucketName, keyPrefix, maxRetries);
-            }
+            uploadFuture = null;
+          }
         } catch (Exception e) {
-            throw new RuntimeException(e);
+          LOG.error("Failed to upload buffer file to S3", e);
         }
+      }, minUploadTime, TimeUnit.SECONDS);
     }
-
-    @Override
-    public LogStream getLogStream() {
-        return this.logStream;
-    }
-
-    @Override
-    public boolean isAuditingEnabled() {
-        return false;
-    }
-
-    @Override
-    public boolean isCommittableWriter() {
-        return true;
-    }
-
-    /**
-     * Takes the fullPathPrefix and removes all slashes and replaces them with underscores.
-     */
-    public static String sanitizeFileName(String fullPathPrefix) {
-        if (fullPathPrefix.startsWith("/")) {
-            fullPathPrefix = fullPathPrefix.substring(1);
-        }
-        return fullPathPrefix.replace("/", "_");
-    }
-
-    /**
-     * Starts the commit process, initializing the buffer file and scheduling an upload task if not already scheduled.
-     *
-     * @param isDraining whether the system is in a draining state
-     * @throws LogStreamWriterException if an error occurs while creating or writing to the buffer file
-     */
-    @Override
-    public synchronized void startCommit(boolean isDraining) throws LogStreamWriterException {
-        try {
-            if (!bufferFile.exists()) {
-                bufferFile.createNewFile();
-            }
-
-            bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
-
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create buffer file: " + bufferFile.getName(), e);
-        }
-        if (uploadFuture == null) {
-            scheduleUploadTask();
-        }
-    }
-
-
-    /**
-     * Schedules a task to upload the buffer file at regular intervals.
-     * If the buffer file exists and has data, it is renamed and a new buffer file is created.
-     * The renamed file is then uploaded to S3.
-     */
-    private void scheduleUploadTask() {
-        synchronized (objLock) {
-            if (uploadFuture != null && !uploadFuture.isDone()) {
-                LOG.info("An upload task is already scheduled or running");
-                return;
-            }
-            uploadFuture = fileUploadTimer.schedule(() -> {
-                try {
-                    synchronized (objLock) {
-                        if (bufferFile.length() > 0) {
-                            bufferedOutputStream.close();
-                            uploadDiskBufferedFileToS3();
-                        }
-                        uploadFuture = null;
-                    }
-                } catch (Exception e) {
-                    LOG.error("Failed to upload buffer file to S3", e);
-                }
-            }, minUploadTime, TimeUnit.SECONDS);
-        }
-    }
+  }
 
   /**
    * Helper function that uploads the disk buffered file to s3
@@ -244,165 +249,181 @@ public class S3Writer implements LogStreamWriter {
     }
   }
 
-    /**
-     * Writes a log message to the buffer file for the current commit.
-     *
-     * @param logMessageAndPosition the log message and its position
-     * @param isDraining whether the system is in a draining state
-     * @throws LogStreamWriterException if an error occurs while writing the log message
-     */
-    @Override
-    public synchronized void writeLogMessageToCommit(LogMessageAndPosition logMessageAndPosition,
-                                                     boolean isDraining) throws LogStreamWriterException {
+  /**
+   * Writes a log message to the buffer file for the current commit.
+   *
+   * @param logMessageAndPosition the log message and its position
+   * @param isDraining whether the system is in a draining state
+   * @throws LogStreamWriterException if an error occurs while writing the log message
+   */
+  @Override
+  public synchronized void writeLogMessageToCommit(LogMessageAndPosition logMessageAndPosition,
+                                                   boolean isDraining)
+      throws LogStreamWriterException {
+    try {
+      writeMessageToBuffer(logMessageAndPosition);
+      OpenTsdbMetricConverter.incr(SingerMetrics.S3_WRITER + "num_messages_written",
+          "bucket=" + bucketName, "host=" + HOSTNAME, "logName=" + logName);
+    } catch (IOException e) {
+      // TODO: Verify if this is retry is needed
+      try {
+        bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
+        writeMessageToBuffer(logMessageAndPosition);
+      } catch (IOException ex) {
+        LOG.error("Failed to close buffer writer", ex);
+        throw new LogStreamWriterException("Failed to write log message to commit", e);
+      }
+    }
+  }
+
+  /**
+   * This method writes the bytes of the log message to the buffered output stream
+   * and adds a newline character after each log message. It then flushes the output stream
+   * to ensure that the data is written to the buffer file.
+   *
+   * @param logMessageAndPosition the log message and its position to be written to the buffer
+   * @throws IOException if an error occurs while writing to the buffer file
+   */
+  private void writeMessageToBuffer(LogMessageAndPosition logMessageAndPosition)
+      throws IOException {
+    byte[] logMessageBytes = logMessageAndPosition.logMessage.getMessage();
+    bufferedOutputStream.write(logMessageBytes);
+    bufferedOutputStream.write('\n'); // Add a newline character after each log message
+    bufferedOutputStream.flush();
+  }
+
+  /**
+   * Resets the buffer file by creating a new buffer file and buffered output stream.
+   *
+   * @throws IOException
+   */
+  private void resetBufferFile() throws IOException {
+    String bufferFileName = sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
+    bufferFile = new File(BUFFER_DIR, bufferFileName);
+    bufferFile.createNewFile();
+    bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
+  }
+
+  /**
+   * Helper function to get the remaining part of the host name after the cluster prefix,
+   * typically a UUID.
+   */
+  public static String extractHostSuffix(String inputStr) {
+    String[] parts = inputStr.split("-");
+    return parts[parts.length - 1];
+  }
+
+  /**
+   * Gets the actual file name format for the S3 file.
+   *
+   * FORMAT: <log_name>/<service_fleet>/<host>/<log_dir>/<custom_filename>.<timestamp>
+   * */
+  public String generateS3ObjectKey() {
+    List<String> hostPrefixes = getHostnamePrefixes("-");
+    String
+        serviceFleet =
+        hostPrefixes.size() == 1 ? hostPrefixes.get(0) : hostPrefixes.get(hostPrefixes.size() - 2);
+    String host = extractHostSuffix(HOSTNAME);
+    String logDir = logStream.getFullPathPrefix().substring(1);
+    String customFilename = s3WriterConfig.getFileNameFormat();
+    String timestamp = FORMATTER.format(new Date());
+    String
+        returnedS3FileFormat =
+        logName + "/" + serviceFleet + "/" + host + "/" + logDir + "/" + customFilename + "."
+            + timestamp;
+    LOG.info("Uploading the file: " + returnedS3FileFormat + " to the bucket " + bucketName
+        + " with key prefix " + keyPrefix);
+    return returnedS3FileFormat;
+  }
+
+  /**
+   * Ends the commit process by flushing the buffer and handling the buffer file if it exceeds
+   * the maximum file size.
+   *
+   * @param numLogMessagesRead the number of log messages read
+   * @param isDraining whether the system is in a draining state
+   * @throws LogStreamWriterException if an error occurs while ending the commit
+   */
+  public synchronized void endCommit(int numLogMessagesRead, boolean isDraining)
+      throws LogStreamWriterException {
+    try {
+      synchronized (objLock) {
+        if (bufferFile.length() >= maxFileSizeMB * BYTES_IN_MB) {
+          if (uploadFuture != null) {
+            uploadFuture.cancel(true);
+          }
+          bufferedOutputStream.close();
+          uploadDiskBufferedFileToS3();
+          scheduleUploadTask();
+        }
+      }
+    } catch (IOException e) {
+      throw new LogStreamWriterException("Failed to end commit", e);
+    }
+  }
+
+  /**
+   * This method should not be used as it is Deprecated. Use comittable write method instead.
+   *
+   * @param messages The LogMessages to be written.
+   * @throws LogStreamWriterException
+   */
+  @Deprecated
+  public void writeLogMessages(List<LogMessage> messages) throws LogStreamWriterException {
+    throw new LogStreamWriterException(
+        "writeLogMessages is not supported. Use writeLogMessagesToCommit instead.");
+  }
+
+
+  /**
+   * Closes the S3Writer, ensuring that remaining buffered log messages are safely uploaded to S3.
+   *
+   * This method synchronizes on {@code objLock} to ensure thread safety while performing the
+   * following steps:
+   * Increments the close counter metric in OpenTsdb.
+   * If the buffer file has remaining data, it renames the file for upload, closes the buffer
+   * stream,
+   * and uploads the file to S3, recording relevant metrics.
+   * Cancels the upload future task if it is not already done.
+   * Attempts to close the buffered output stream if it is still open.
+   * Closes the S3 client connection.
+   * Any errors during these operations are logged accordingly.
+   *
+   * @throws IOException
+   */
+  @Override
+  public void close() throws IOException {
+    synchronized (objLock) {
+      OpenTsdbMetricConverter.incr(SingerMetrics.S3_WRITER + "num_singer_close", 1,
+          "bucket=" + bucketName, "keyPrefix=" + keyPrefix, "host=" + HOSTNAME,
+          "logName=" + logName);
+
+      if (bufferFile.length() > 0) {
         try {
-            writeMessageToBuffer(logMessageAndPosition);
-            OpenTsdbMetricConverter.incr(SingerMetrics.S3_WRITER + "num_messages_written",
-              "bucket=" + bucketName, "host=" + HOSTNAME, "logName=" + logName);
+          bufferedOutputStream.close();
+          uploadDiskBufferedFileToS3();
+          bufferFile.delete();
         } catch (IOException e) {
-            // TODO: Verify if this is retry is needed
-            try {
-                bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
-                writeMessageToBuffer(logMessageAndPosition);
-            } catch (IOException ex) {
-                LOG.error("Failed to close buffer writer", ex);
-                throw new LogStreamWriterException("Failed to write log message to commit", e);
-            }
+          LOG.error("Failed to close bufferedWriter or upload buffer file: " + bufferFile.getName(),
+              e);
         }
-    }
+      }
 
-    /**
-     * This method writes the bytes of the log message to the buffered output stream
-     * and adds a newline character after each log message. It then flushes the output stream
-     * to ensure that the data is written to the buffer file.
-     *
-     * @param logMessageAndPosition the log message and its position to be written to the buffer
-     * @throws IOException if an error occurs while writing to the buffer file
-     */
-    private void writeMessageToBuffer(LogMessageAndPosition logMessageAndPosition) throws IOException {
-        byte[] logMessageBytes = logMessageAndPosition.logMessage.getMessage();
-        bufferedOutputStream.write(logMessageBytes);
-        bufferedOutputStream.write('\n'); // Add a newline character after each log message
-        bufferedOutputStream.flush();
-    }
+      if (uploadFuture != null && !uploadFuture.isDone()) {
+        uploadFuture.cancel(true);
+      }
 
-    /**
-     * Resets the buffer file by creating a new buffer file and buffered output stream.
-     *
-     * @throws IOException
-     */
-    private void resetBufferFile() throws IOException {
-      String bufferFileName = sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
-      bufferFile = new File(BUFFER_DIR, bufferFileName);
-      bufferFile.createNewFile();
-      bufferedOutputStream = new BufferedOutputStream(new FileOutputStream(bufferFile, true));
-    }
-
-    /**
-     * Helper function to get the remaining part of the host name after the cluster prefix, typically a UUID.
-     */
-    public static String extractHostSuffix(String inputStr) {
-        String[] parts = inputStr.split("-");
-        return parts[parts.length - 1];
-    }
-
-    /**
-     * Gets the actual file name format for the S3 file.
-     *
-     * FORMAT: <log_name>/<service_fleet>/<host>/<log_dir>/<custom_filename>.<timestamp>
-     * */
-    public String generateS3ObjectKey() {
-        List<String> hostPrefixes = getHostnamePrefixes("-");
-        String serviceFleet = hostPrefixes.size() == 1 ? hostPrefixes.get(0) : hostPrefixes.get(hostPrefixes.size() - 2);
-        String host = extractHostSuffix(HOSTNAME);
-        String logDir = logStream.getFullPathPrefix().substring(1);
-        String customFilename = s3WriterConfig.getFileNameFormat();
-        String timestamp = FORMATTER.format(new Date());
-        String returnedS3FileFormat = logName + "/" + serviceFleet + "/" + host + "/" + logDir + "/" + customFilename + "." + timestamp;
-        LOG.info("Uploading the file: " + returnedS3FileFormat + " to the bucket " + bucketName + " with key prefix " + keyPrefix);
-        return returnedS3FileFormat;
-    }
-
-    /**
-     * Ends the commit process by flushing the buffer and handling the buffer file if it exceeds the maximum file size.
-     *
-     * @param numLogMessagesRead the number of log messages read
-     * @param isDraining whether the system is in a draining state
-     * @throws LogStreamWriterException if an error occurs while ending the commit
-     */
-    public synchronized void endCommit(int numLogMessagesRead, boolean isDraining) throws LogStreamWriterException {
-        try {
-            synchronized (objLock) {
-                if (bufferFile.length() >= maxFileSizeMB * BYTES_IN_MB) {
-                    if (uploadFuture != null) {
-                        uploadFuture.cancel(true);
-                    }
-                    bufferedOutputStream.close();
-                    uploadDiskBufferedFileToS3();
-                    scheduleUploadTask();
-                }
-            }
-        } catch (IOException e) {
-            throw new LogStreamWriterException("Failed to end commit", e);
+      try {
+        if (bufferedOutputStream != null) {
+          bufferedOutputStream.close();
         }
+      } catch (IOException e) {
+        LOG.error("Failed to close buffer writers", e);
+      }
+
+      if (s3Client != null) {
+        s3Client.close();
+      }
     }
-
-    /**
-     * This method should not be used as it is Deprecated. Use comittable write method instead.
-     *
-     * @param messages The LogMessages to be written.
-     * @throws LogStreamWriterException
-     */
-    @Deprecated
-    public void writeLogMessages(List<LogMessage> messages) throws LogStreamWriterException {
-        throw new LogStreamWriterException("writeLogMessages is not supported. Use writeLogMessagesToCommit instead.");
-    }
-
-
-    /**
-     * Closes the S3Writer, ensuring that remaining buffered log messages are safely uploaded to S3.
-     *
-     * This method synchronizes on {@code objLock} to ensure thread safety while performing the following steps:
-     * Increments the close counter metric in OpenTsdb.
-     * If the buffer file has remaining data, it renames the file for upload, closes the buffer stream,
-     * and uploads the file to S3, recording relevant metrics.
-     * Cancels the upload future task if it is not already done.
-     * Attempts to close the buffered output stream if it is still open.
-     * Closes the S3 client connection.
-     * Any errors during these operations are logged accordingly.
-     *
-     * @throws IOException
-     */
-    @Override
-    public void close() throws IOException {
-        synchronized (objLock) {
-            OpenTsdbMetricConverter.incr(SingerMetrics.S3_WRITER + "num_singer_close", 1,
-                    "bucket=" + bucketName, "keyPrefix=" + keyPrefix, "host=" + HOSTNAME, "logName=" + logName);
-
-            if (bufferFile.length() > 0) {
-                try {
-                    bufferedOutputStream.close();
-                    uploadDiskBufferedFileToS3();
-                    bufferFile.delete();
-                } catch (IOException e) {
-                    LOG.error("Failed to close bufferedWriter or upload buffer file: " + bufferFile.getName(), e);
-                }
-            }
-
-            if (uploadFuture != null && !uploadFuture.isDone()) {
-                uploadFuture.cancel(true);
-            }
-
-            try {
-                if (bufferedOutputStream != null) {
-                    bufferedOutputStream.close();
-                }
-            } catch (IOException e) {
-                LOG.error("Failed to close buffer writers", e);
-            }
-
-            if (s3Client != null) {
-                s3Client.close();
-            }
-        }
-    }
+  }
 }

--- a/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
@@ -138,34 +138,6 @@ public class S3WriterTest extends SingerTestBase {
     }
 
     @Test
-    public void testGetFileName() {
-        String input = "application.log";
-        String expected = "application";
-        String result = S3Writer.getFileName(input);
-        assertEquals(expected, result);
-
-        input = "anotherFile.txt";
-        expected = "anotherFile.txt";
-        result = S3Writer.getFileName(input);
-        assertEquals(expected, result);
-
-        input = "logfile";
-        expected = "logfile";
-        result = S3Writer.getFileName(input);
-        assertEquals(expected, result);
-
-        input = ".log";
-        expected = "";
-        result = S3Writer.getFileName(input);
-        assertEquals(expected, result);
-
-        input = "";
-        expected = "";
-        result = S3Writer.getFileName(input);
-        assertEquals(expected, result);
-    }
-
-    @Test
     public void testWriteLogMessageToCommit() throws Exception {
         // Prepare log message
         ByteBuffer messageBuffer = ByteBuffer.wrap("test message".getBytes());


### PR DESCRIPTION
S3Writer refactor changes included:

- Delete unused and redundant helper methods and class fields
- Introduce helper functions to reduce code duplicates
- Change `File.renameTo()` to `Files.move()` for buffer file renaming. The latter is much more reliable and offers better error handling
- Consolidate upload logic to one single method
- Add more comments and javadoc
- Add metric for number of messages written to buffer (so it can be compared with upstream logger metric)
- Introduce "logName" derived from singer log config name to use instead of `logStream.getLogStreamName()`