### PR TITLE
Implement custom format for object keys uploaded by S3Writer

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -119,13 +119,29 @@ struct NoOpWriteConfig {
 }
 
 struct S3WriterConfig {
+  // The S3 bucket to upload the log files to.
   1: required string bucket;
-  2: required string keyPrefix;
-  3: optional i32 minUploadTimeInSeconds = 30;
-  4: optional i32 maxFileSizeMB = 50;
-  5: required string fileNameFormat;
-  6: optional i32 maxRetries = 5;
-  7: optional string bufferDir = "/tmp/singer/s3";
+  // The format of the key to be used for the S3 object. The key can contain tokens that will be replaced
+  // with the values extracted from the log filename based on the regex pattern provided in filenamePattern.
+  // e.g. "%{namespace}/%{service}/my_log.%UUID".
+  2: required string keyFormat;
+  // Max file size in MB. If the file size exceeds this value, it will be uploaded to S3.
+  3: optional i32 maxFileSizeMB = 50;
+  // Min upload time in seconds. If the file size exceeds this value, it will be uploaded to S3.
+  4: optional i32 minUploadTimeInSeconds = 30;
+  // The maximum number of retries for uploading a file to S3 before giving up.
+  // Retry mechanism uses exponential backoff.
+  5: optional i32 maxRetries = 5;
+  // The directory where the log messages will be buffered before triggering
+  // the upload to S3. The directory will be created if it does not exist.
+  6: optional string bufferDir = "/tmp/singer/s3";
+  // The regex pattern used to extract specific fields from the filename.
+  // e.g. "^(?<service>[a-zA-Z0-9]+)_.*_(?<index>\\d+)\\.log$" will extract the "service" and "1000"
+  // tokens from the filename "service_env_1000.log".
+  7: optional string filenamePattern;
+  // A comma separated list of named capturing groups that will be extracted from the filename based on the regex pattern provided in filenamePattern.
+  // The extracted fields will be used to replace the tokens in keyFormat, e.g "namespace,service".
+  8: optional list<string> filenameTokens;
 }
 
 enum RealpinObjectType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -103,11 +103,11 @@ public class SingerConfigDef {
   public static final String SKIP_DRAINING = "skipDraining";
 
   public static final String BUCKET = "bucket";
-  public static final String KEY_PREFIX = "keyPrefix";
-  public static final String MAX_FILE_SIZE_IN_BYTES = "maxFileSizeInBytes";
+  public static final String KEY_FORMAT = "keyFormat";
   public static final String MAX_FILE_SIZE_MB = "maxFileSizeMB";
   public static final String MIN_UPLOAD_TIME_IN_SECONDS = "minUploadTimeInSeconds";
-  public static final String FILE_NAME_FORMAT = "fileNameFormat";
+  public static final String FILE_NAME_PATTERN = "filenamePattern";
   public static final String MAX_RETRIES = "maxRetries";
   public static final String BUFFER_DIR = "bufferDir";
+  public static final String NAMED_GROUP_PATTERN = "\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>";
 }

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
@@ -13,15 +13,13 @@ public class ObjectUploaderTask {
     private static final Logger LOG = LoggerFactory.getLogger(S3Writer.class);
     private final S3Client s3Client;
     private final String bucket;
-    private final String keyPrefix;
     private final int maxRetries;
     private static final long INITIAL_BACKOFF = 1000; // Initial backoff in milliseconds
     private static final long MAX_BACKOFF = 32000; // Maximum backoff in milliseconds
 
-    public ObjectUploaderTask(S3Client s3Client, String bucket, String keyPrefix, int maxRetries) {
+    public ObjectUploaderTask(S3Client s3Client, String bucket, int maxRetries) {
         this.s3Client = s3Client;
         this.bucket = bucket;
-        this.keyPrefix = keyPrefix;
         this.maxRetries = maxRetries;
     }
 
@@ -43,7 +41,7 @@ public class ObjectUploaderTask {
             try {
                 PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                         .bucket(bucket)
-                        .key(keyPrefix + fileFormat)
+                        .key(fileFormat)
                         .build();
 
                 PutObjectResponse putObjectResponse = s3Client.putObject(putObjectRequest, file.toPath());

--- a/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
@@ -58,10 +58,8 @@ public class S3WriterTest extends SingerTestBase {
 
     // Initialize basics
     tempPath = getTempPath();
-    String logStreamHeadFileName = "thrift.log";
-    String path = FilenameUtils.concat(tempPath, logStreamHeadFileName);
     SingerLogConfig singerLogConfig = createSingerLogConfig("testLog", tempPath);
-    SingerLog singerLog = new SingerLog(singerLogConfig);
+    singerLog = new SingerLog(singerLogConfig);
     logStream = new LogStream(singerLog, "test_log");
 
     // Initialize S3WriterConfig

--- a/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
@@ -11,6 +11,7 @@ import com.pinterest.singer.utils.SingerUtils;
 import com.pinterest.singer.writer.s3.ObjectUploaderTask;
 import com.pinterest.singer.writer.s3.S3Writer;
 import com.pinterest.singer.writer.s3.S3Writer.DefaultTokens;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.After;
@@ -38,227 +39,234 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class S3WriterTest extends SingerTestBase {
 
-    @Mock
-    private S3Client mockS3Client;
+  @Mock
+  private S3Client mockS3Client;
 
-    @Mock
-    private ObjectUploaderTask mockObjectUploaderTask;
+  @Mock
+  private ObjectUploaderTask mockObjectUploaderTask;
 
-    private S3Writer s3Writer;
-    private SingerLog singerLog;
-    private LogStream logStream;
-    private S3WriterConfig s3WriterConfig;
-    private String tempPath;
+  private S3Writer s3Writer;
+  private SingerLog singerLog;
+  private LogStream logStream;
+  private S3WriterConfig s3WriterConfig;
+  private String tempPath;
 
-    @Before
-    public void setUp() {
-        // set hostname
-        SingerUtils.setHostname("localhost-dev", "-");
+  @Before
+  public void setUp() {
+    // set hostname
+    SingerUtils.setHostname("localhost-dev", "-");
 
-        // Initialize basics
-        tempPath = getTempPath();
-        String logStreamHeadFileName = "thrift.log";
-        String path = FilenameUtils.concat(tempPath, logStreamHeadFileName);
-        SingerLogConfig singerLogConfig = createSingerLogConfig("testLog", tempPath);
-        SingerLog singerLog = new SingerLog(singerLogConfig);
-        logStream = new LogStream(singerLog, "test_log");
+    // Initialize basics
+    tempPath = getTempPath();
+    String logStreamHeadFileName = "thrift.log";
+    String path = FilenameUtils.concat(tempPath, logStreamHeadFileName);
+    SingerLogConfig singerLogConfig = createSingerLogConfig("testLog", tempPath);
+    SingerLog singerLog = new SingerLog(singerLogConfig);
+    logStream = new LogStream(singerLog, "test_log");
 
-        // Initialize S3WriterConfig
-        s3WriterConfig = new S3WriterConfig();
-        s3WriterConfig.setBucket("bucket-name");
-        s3WriterConfig.setKeyFormat("key-prefix");
-        s3WriterConfig.setMaxFileSizeMB(1);
-        s3WriterConfig.setMinUploadTimeInSeconds(5);
-        s3WriterConfig.setMaxRetries(3);
+    // Initialize S3WriterConfig
+    s3WriterConfig = new S3WriterConfig();
+    s3WriterConfig.setBucket("bucket-name");
+    s3WriterConfig.setKeyFormat("key-prefix");
+    s3WriterConfig.setMaxFileSizeMB(1);
+    s3WriterConfig.setMinUploadTimeInSeconds(5);
+    s3WriterConfig.setMaxRetries(3);
 
-        // Initialize the S3Writer with mock dependencies
-        s3Writer = new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
+    // Initialize the S3Writer with mock dependencies
+    s3Writer =
+        new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    File testBaseDir = new File(tempPath);
+    if (testBaseDir.exists()) {
+      FileUtils.deleteDirectory(testBaseDir);
     }
+  }
 
-    @After
-    public void tearDown() throws IOException {
-        File testBaseDir = new File(tempPath);
-        if (testBaseDir.exists()) {
-            FileUtils.deleteDirectory(testBaseDir);
-        }
+
+  @Test
+  public void testSanitizeFileName() {
+    String fullPathPrefix = "/var/logs/app";
+    String expected = "var_logs_app";
+    String result = s3Writer.sanitizeFileName(fullPathPrefix);
+    assertEquals(expected, result);
+
+    fullPathPrefix = "var/logs/app";
+    expected = "var_logs_app";
+    result = s3Writer.sanitizeFileName(fullPathPrefix);
+    assertEquals(expected, result);
+
+    fullPathPrefix = "/var/logs/app/";
+    expected = "var_logs_app_";
+    result = s3Writer.sanitizeFileName(fullPathPrefix);
+    assertEquals(expected, result);
+
+    fullPathPrefix = "/";
+    expected = "";
+    result = s3Writer.sanitizeFileName(fullPathPrefix);
+    assertEquals(expected, result);
+
+    fullPathPrefix = "";
+    expected = "";
+    result = s3Writer.sanitizeFileName(fullPathPrefix);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testExtractHostSuffix() {
+    String hostname = "app-server-12345";
+    String expected = "12345";
+    String result = S3Writer.extractHostSuffix(hostname);
+    assertEquals(expected, result);
+
+    hostname = "app-12345";
+    expected = "12345";
+    result = S3Writer.extractHostSuffix(hostname);
+    assertEquals(expected, result);
+
+    hostname = "12345";
+    expected = "12345";
+    result = S3Writer.extractHostSuffix(hostname);
+    assertEquals(expected, result);
+
+    hostname = "app-server";
+    expected = "server";
+    result = S3Writer.extractHostSuffix(hostname);
+    assertEquals(expected, result);
+
+    hostname = "";
+    expected = "";
+    result = S3Writer.extractHostSuffix(hostname);
+    assertEquals(expected, result);
+  }
+
+  @Test
+  public void testWriteLogMessageToCommit() throws Exception {
+    // Prepare log message
+    ByteBuffer messageBuffer = ByteBuffer.wrap("test message".getBytes());
+    LogMessage logMessage = new LogMessage(messageBuffer);
+    LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
+
+    // Write log message to commit
+    s3Writer.startCommit(false);
+    s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
+    s3Writer.endCommit(1, false);
+
+    // Verify that the messages are written to the buffer file
+    String
+        bufferFileName =
+        s3Writer.sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
+    File bufferFile = new File(FilenameUtils.concat(tempPath, bufferFileName));
+    assertTrue(bufferFile.exists());
+    String content = new String(Files.readAllBytes(bufferFile.toPath()));
+    assertTrue(content.contains("test message"));
+  }
+
+  @Test
+  public void testUploadToS3WhenSizeThresholdMet() throws Exception {
+    // Prepare log message
+    LogMessage
+        logMessage =
+        new LogMessage(ByteBuffer.wrap(new byte[1024 * 1024])); // simulate 1MB message
+    LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
+
+    // Mock upload behavior
+    when(mockObjectUploaderTask.upload(any(File.class), anyString())).thenReturn(true);
+
+    // Write log messages to commit
+    s3Writer.startCommit(false);
+    for (int i = 0; i < 51; i++) { // Write enough to exceed the threshold
+      s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
     }
+    s3Writer.endCommit(2, false);
 
+    // Verify upload was called
+    verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
+  }
 
-    @Test
-    public void testSanitizeFileName() {
-        String fullPathPrefix = "/var/logs/app";
-        String expected = "var_logs_app";
-        String result = s3Writer.sanitizeFileName(fullPathPrefix);
-        assertEquals(expected, result);
+  @Test
+  public void testUploadIsScheduled() throws Exception {
+    // Prepare log message
+    ByteBuffer messageBuffer = ByteBuffer.wrap(new byte[1024]); // simulate 1KB message
+    LogMessage logMessage = new LogMessage(messageBuffer);
+    LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
 
-        fullPathPrefix = "var/logs/app";
-        expected = "var_logs_app";
-        result = s3Writer.sanitizeFileName(fullPathPrefix);
-        assertEquals(expected, result);
+    // Mock upload behavior
+    when(mockObjectUploaderTask.upload(any(File.class), anyString())).thenReturn(true);
 
-        fullPathPrefix = "/var/logs/app/";
-        expected = "var_logs_app_";
-        result = s3Writer.sanitizeFileName(fullPathPrefix);
-        assertEquals(expected, result);
+    // Write log messages to commit
+    s3Writer.startCommit(false);
+    s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
 
-        fullPathPrefix = "/";
-        expected = "";
-        result = s3Writer.sanitizeFileName(fullPathPrefix);
-        assertEquals(expected, result);
+    // Simulate passage of time and scheduled upload
+    Thread.sleep((s3WriterConfig.getMinUploadTimeInSeconds() + 2) * 1000);
 
-        fullPathPrefix = "";
-        expected = "";
-        result = s3Writer.sanitizeFileName(fullPathPrefix);
-        assertEquals(expected, result);
-    }
+    s3Writer.endCommit(1, false);
 
-    @Test
-    public void testExtractHostSuffix() {
-        String hostname = "app-server-12345";
-        String expected = "12345";
-        String result = S3Writer.extractHostSuffix(hostname);
-        assertEquals(expected, result);
+    // Verify upload was called
+    verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
+  }
 
-        hostname = "app-12345";
-        expected = "12345";
-        result = S3Writer.extractHostSuffix(hostname);
-        assertEquals(expected, result);
+  @Test
+  public void testS3ObjectKeyGeneration() {
+    // Custom and default tokens used
+    String
+        keyFormat =
+        "my-path/%{namespace}/" + DefaultTokens.LOGNAME.getValue() + "/%{filename}-%{index}."
+            + DefaultTokens.TIMESTAMP.getValue();
+    logStream = new LogStream(singerLog, "my_namespace-test_log.0");
+    s3WriterConfig = new S3WriterConfig();
+    s3WriterConfig.setKeyFormat(keyFormat);
+    s3WriterConfig.setBucket("bucket-name");
+    s3WriterConfig.setFilenamePattern("(?<namespace>[^-]+)-(?<filename>[^.]+)\\.(?<index>\\d+)");
+    s3WriterConfig.setFilenameTokens(Arrays.asList("namespace", "filename", "index"));
+    s3Writer =
+        new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
+    // Check key prefix
+    String[] objectKeyParts = s3Writer.generateS3ObjectKey().split("/");
+    assertEquals(4, objectKeyParts.length);
+    assertEquals("my-path", objectKeyParts[0]);
+    assertEquals("my_namespace", objectKeyParts[1]);
+    assertEquals(logStream.getSingerLog().getSingerLogConfig().getName(), objectKeyParts[2]);
+    // Check last part of object key
+    String[] keySuffixParts = objectKeyParts[3].split("\\.");
+    assertEquals(3, keySuffixParts.length);
+    assertEquals("test_log-0", keySuffixParts[0]);
+    assertNotEquals(DefaultTokens.LOGNAME.getValue(), keySuffixParts[1]);
+    // Custom tokens provided but filename pattern does not match
+    s3WriterConfig.setFilenamePattern("(?<filename>[^.]+)\\.(?<index>\\d+).0");
+    s3Writer =
+        new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
+    objectKeyParts = s3Writer.generateS3ObjectKey().split("/");
+    assertEquals("%{namespace}", objectKeyParts[1]);
+    keySuffixParts = objectKeyParts[3].split("\\.");
+    assertEquals("%{filename}-%{index}", keySuffixParts[0]);
+  }
 
-        hostname = "12345";
-        expected = "12345";
-        result = S3Writer.extractHostSuffix(hostname);
-        assertEquals(expected, result);
+  @Test
+  public void testClose() throws Exception {
+    // Prepare log message
+    ByteBuffer messageBuffer = ByteBuffer.wrap("test message".getBytes());
+    LogMessage logMessage = new LogMessage(messageBuffer);
+    LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
 
-        hostname = "app-server";
-        expected = "server";
-        result = S3Writer.extractHostSuffix(hostname);
-        assertEquals(expected, result);
+    // Write log message to commit
+    s3Writer.startCommit(false);
+    s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
+    s3Writer.endCommit(1, false);
 
-        hostname = "";
-        expected = "";
-        result = S3Writer.extractHostSuffix(hostname);
-        assertEquals(expected, result);
-    }
+    // Call close
+    s3Writer.close();
 
-    @Test
-    public void testWriteLogMessageToCommit() throws Exception {
-        // Prepare log message
-        ByteBuffer messageBuffer = ByteBuffer.wrap("test message".getBytes());
-        LogMessage logMessage = new LogMessage(messageBuffer);
-        LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
-
-        // Write log message to commit
-        s3Writer.startCommit(false);
-        s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
-        s3Writer.endCommit(1, false);
-
-        // Verify that the messages are written to the buffer file
-        String bufferFileName = s3Writer.sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
-        File bufferFile = new File(FilenameUtils.concat(tempPath, bufferFileName));
-        assertTrue(bufferFile.exists());
-        String content = new String(Files.readAllBytes(bufferFile.toPath()));
-        assertTrue(content.contains("test message"));
-    }
-
-    @Test
-    public void testUploadToS3WhenSizeThresholdMet() throws Exception {
-        // Prepare log message
-        LogMessage logMessage = new LogMessage(ByteBuffer.wrap(new byte[1024 * 1024])); // simulate 1MB message
-        LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
-
-        // Mock upload behavior
-        when(mockObjectUploaderTask.upload(any(File.class), anyString())).thenReturn(true);
-
-        // Write log messages to commit
-        s3Writer.startCommit(false);
-        for (int i = 0; i < 51; i++) { // Write enough to exceed the threshold
-            s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
-        }
-        s3Writer.endCommit(2, false);
-
-        // Verify upload was called
-        verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
-    }
-
-    @Test
-    public void testUploadIsScheduled() throws Exception {
-        // Prepare log message
-        ByteBuffer messageBuffer = ByteBuffer.wrap(new byte[1024]); // simulate 1KB message
-        LogMessage logMessage = new LogMessage(messageBuffer);
-        LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
-
-        // Mock upload behavior
-        when(mockObjectUploaderTask.upload(any(File.class), anyString())).thenReturn(true);
-
-        // Write log messages to commit
-        s3Writer.startCommit(false);
-        s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
-
-        // Simulate passage of time and scheduled upload
-        Thread.sleep((s3WriterConfig.getMinUploadTimeInSeconds() + 2) * 1000);
-
-        s3Writer.endCommit(1, false);
-
-        // Verify upload was called
-        verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
-    }
-
-    @Test
-    public void testS3ObjectKeyGeneration() {
-      // Custom and default tokens used
-      String
-          keyFormat =
-          "my-path/%{namespace}/" + DefaultTokens.LOGNAME.getValue() + "/%{filename}-%{index}."
-              + DefaultTokens.TIMESTAMP.getValue();
-      logStream = new LogStream(singerLog, "my_namespace-test_log.0");
-      s3WriterConfig = new S3WriterConfig();
-      s3WriterConfig.setKeyFormat(keyFormat);
-      s3WriterConfig.setBucket("bucket-name");
-      s3WriterConfig.setFilenamePattern("(?<namespace>[^-]+)-(?<filename>[^.]+)\\.(?<index>\\d+)");
-      s3WriterConfig.setFilenameTokens(Arrays.asList("namespace", "filename", "index"));
-      s3Writer =
-          new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
-      // Check key prefix
-      String[] objectKeyParts = s3Writer.generateS3ObjectKey().split("/");
-      assertEquals(4, objectKeyParts.length);
-      assertEquals("my-path", objectKeyParts[0]);
-      assertEquals("my_namespace", objectKeyParts[1]);
-      assertEquals(logStream.getSingerLog().getSingerLogConfig().getName(), objectKeyParts[2]);
-      // Check last part of object key
-      String[] keySuffixParts = objectKeyParts[3].split("\\.");
-      assertEquals(3, keySuffixParts.length);
-      assertEquals("test_log-0", keySuffixParts[0]);
-      assertNotEquals(DefaultTokens.LOGNAME.getValue(), keySuffixParts[1]);
-      // Custom tokens provided but filename pattern does not match
-      s3WriterConfig.setFilenamePattern("(?<filename>[^.]+)\\.(?<index>\\d+).0");
-      s3Writer =
-          new S3Writer(logStream, s3WriterConfig, mockS3Client, mockObjectUploaderTask, tempPath);
-      objectKeyParts = s3Writer.generateS3ObjectKey().split("/");
-      assertEquals("%{namespace}", objectKeyParts[1]);
-      keySuffixParts = objectKeyParts[3].split("\\.");
-      assertEquals("%{filename}-%{index}", keySuffixParts[0]);
-    }
-
-    @Test
-    public void testClose() throws Exception {
-        // Prepare log message
-        ByteBuffer messageBuffer = ByteBuffer.wrap("test message".getBytes());
-        LogMessage logMessage = new LogMessage(messageBuffer);
-        LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, null);
-
-        // Write log message to commit
-        s3Writer.startCommit(false);
-        s3Writer.writeLogMessageToCommit(logMessageAndPosition, false);
-        s3Writer.endCommit(1, false);
-
-        // Call close
-        s3Writer.close();
-
-        // Verify that the buffer file was correctly handled
-        String bufferFileName = s3Writer.sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
-        File bufferFile = new File(FilenameUtils.concat(tempPath, bufferFileName));
-        assertTrue(!bufferFile.exists());
-        assertEquals(0, bufferFile.length());
-        verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
-    }
+    // Verify that the buffer file was correctly handled
+    String
+        bufferFileName =
+        s3Writer.sanitizeFileName(logStream.getFullPathPrefix()) + ".buffer.log";
+    File bufferFile = new File(FilenameUtils.concat(tempPath, bufferFileName));
+    assertTrue(!bufferFile.exists());
+    assertEquals(0, bufferFile.length());
+    verify(mockObjectUploaderTask, atLeastOnce()).upload(any(File.class), anyString());
+  }
 }


### PR DESCRIPTION
This PR introduces 2 new configs to S3Writer to allow for more customizable format for object uploads: 

- `filenamePattern` : A regex to extract fields/tokens out of the filename
- `filenameTokens` : A list of tokens extracted from filenamePattern, these are extracted automatically but can also be set for testing

`keyPrefix` and `filenameFormat` are also replaced with `keyFormat` so that tokens extracted from the flename can be used in `keyFormat` by following the syntax: `%{TOKEN}`, e.g: 

```
# Configuration for writer
writer.type=s3
writer.s3.maxFileSizeMB=5
writer.s3.minUploadTimeInSeconds=30
writer.s3.bucket=my-bucket
writer.s3.keyFormat=%{service}/%{index}/my_log.%TIMESTAMP
writer.s3.maxRetries=3
writer.s3.filenamePattern=^(?<service>[a-zA-Z0-9]+)_.*_(?<index>\\d+)\\.log$
```

Additionally, we add some default formatters:

- %UUID
- %TIMESTAMP
- %HOST
- %LOGNAME