### PR TITLE
S3Writer: Add canned acl support

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -142,6 +142,9 @@ struct S3WriterConfig {
   // A comma separated list of named capturing groups that will be extracted from the filename based on the regex pattern provided in filenamePattern.
   // The extracted fields will be used to replace the tokens in keyFormat, e.g "namespace,service".
   8: optional list<string> filenameTokens;
+  // The S3 canned access control lists (ACLs) that can be applied to uploaded objects to determine their access permissions.
+  // We don't set a default since some buckets don't allow setting canned ACLs.
+  9: optional string cannedAcl;
 }
 
 enum RealpinObjectType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -109,5 +109,6 @@ public class SingerConfigDef {
   public static final String FILE_NAME_PATTERN = "filenamePattern";
   public static final String MAX_RETRIES = "maxRetries";
   public static final String BUFFER_DIR = "bufferDir";
+  public static final String CANNED_ACL = "cannedAcl";
   public static final String NAMED_GROUP_PATTERN = "\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>";
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -82,6 +82,7 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.record.CompressionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -802,6 +803,17 @@ public class LogConfigUtils {
       }
       config.setFilenamePattern(filenamePattern);
       config.setFilenameTokens(tokenList);
+    }
+
+    if (writerConfiguration.containsKey(SingerConfigDef.CANNED_ACL)) {
+      try {
+        // Check if the canned ACL is valid
+        String cannedAcl = writerConfiguration.getString(SingerConfigDef.CANNED_ACL);
+        ObjectCannedACL.fromValue(cannedAcl);
+        config.setCannedAcl(cannedAcl);
+      } catch (IllegalArgumentException e) {
+        throw new ConfigurationException("Unknown canned ACL provided: " + writerConfiguration.getString(SingerConfigDef.CANNED_ACL), e);
+      }
     }
 
     // Override maxFileSize if it is less than the default value

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/ObjectUploaderTask.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
@@ -13,13 +14,16 @@ public class ObjectUploaderTask {
     private static final Logger LOG = LoggerFactory.getLogger(S3Writer.class);
     private final S3Client s3Client;
     private final String bucket;
+    private final ObjectCannedACL cannedAcl;
     private final int maxRetries;
     private static final long INITIAL_BACKOFF = 1000; // Initial backoff in milliseconds
     private static final long MAX_BACKOFF = 32000; // Maximum backoff in milliseconds
 
-    public ObjectUploaderTask(S3Client s3Client, String bucket, int maxRetries) {
+    public ObjectUploaderTask(S3Client s3Client, String bucket, ObjectCannedACL cannedAcl,
+                              int maxRetries) {
         this.s3Client = s3Client;
         this.bucket = bucket;
+        this.cannedAcl = cannedAcl;
         this.maxRetries = maxRetries;
     }
 
@@ -43,6 +47,10 @@ public class ObjectUploaderTask {
                         .bucket(bucket)
                         .key(fileFormat)
                         .build();
+
+                if (cannedAcl != null) {
+                    putObjectRequest = putObjectRequest.toBuilder().acl(cannedAcl).build();
+                }
 
                 PutObjectResponse putObjectResponse = s3Client.putObject(putObjectRequest, file.toPath());
 

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
@@ -36,6 +36,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 
 /**
  * A LogStreamWriter for Singer that writes to S3 (writer.type=s3).
@@ -163,7 +164,9 @@ public class S3Writer implements LogStreamWriter {
         s3Client = S3Client.builder().build();
       }
       if (putObjectUploader == null) {
-        putObjectUploader = new ObjectUploaderTask(s3Client, bucketName, maxRetries);
+        putObjectUploader =
+            new ObjectUploaderTask(s3Client, bucketName,
+                ObjectCannedACL.fromValue(s3WriterConfig.getCannedAcl()), maxRetries);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
@@ -451,7 +451,8 @@ public class TestLogConfigUtils {
         config =
         "type=s3\n" + "s3.bucket=my-fav-bucket\n" + "s3.keyFormat=%{service}/%{index}/my_log\n"
             + "s3.maxFileSizeMB=100\n" + "s3.minUploadTimeInSeconds=1\n" + "s3.maxRetries=10\n"
-            + "s3.filenamePattern=^(?<service>[a-zA-Z0-9]+)_.*_(?<index>\\\\d+)\\\\.log$";
+            + "s3.filenamePattern=^(?<service>[a-zA-Z0-9]+)_.*_(?<index>\\\\d+)\\\\.log$\n"
+            + "s3.cannedAcl=bucket-owner-full-control";
     PropertiesConfiguration conf = new PropertiesConfiguration();
     conf.load(new ByteArrayInputStream(config.getBytes()));
     List<String> tokens = new ArrayList<>();


### PR DESCRIPTION
Add configuration to add canned acl to objects uploaded by S3Writer, more info on canned ACLs: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl