### PR TITLE
Exclude hidden files from logstream regex discovery

### DIFF
--- a/singer/src/test/java/com/pinterest/singer/monitor/FileSystemMonitorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/monitor/FileSystemMonitorTest.java
@@ -20,6 +20,7 @@ import com.pinterest.singer.common.SingerLog;
 import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.LogFileAndPath;
+import com.pinterest.singer.thrift.configuration.FileNameMatchMode;
 import com.pinterest.singer.thrift.configuration.SingerConfig;
 import com.pinterest.singer.thrift.configuration.SingerLogConfig;
 import com.pinterest.singer.utils.SingerUtils;
@@ -31,6 +32,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -361,5 +364,40 @@ public class FileSystemMonitorTest extends com.pinterest.singer.SingerTestBase {
     Thread.sleep(FILE_EVENT_WAIT_TIME_MS);
     toMonitor.logStatus();
     assertTrue(toMonitor.checkConsistency());
-  } 
+  }
+
+  @Test
+  public void testExcludeWatermarkFilesFromDiscovery() throws Exception {
+    final File testDir = this.tempDir.newFolder();
+    final String LOG_FILE_PREFIX = "test_001.tmp";
+    final String LOGSTREAM_REGEX = ".*test.*";
+
+    int NUM_FILES = 10;
+    File[] created = createTestLogStreamFiles(testDir, LOG_FILE_PREFIX, NUM_FILES);
+    String[] createdFiles = new String[NUM_FILES];
+    for (int i = 0; i < NUM_FILES; i++) {
+      createdFiles[i] = created[i].getName();
+      // Create a dot file to simulate a watermark file for each log file
+      File file = new File(testDir + "/." + createdFiles[i]);
+      file.createNewFile();
+    }
+
+    SingerConfig singerConfig = new SingerConfig();
+    SingerLogConfig logStreamConfig = new SingerLogConfig();
+    logStreamConfig.setName("test_logstream");
+    logStreamConfig.setLogDir(testDir.getAbsolutePath());
+    logStreamConfig.setFilenameMatchMode(FileNameMatchMode.EXACT);
+    logStreamConfig.setLogStreamRegex(LOGSTREAM_REGEX);
+    singerConfig.setLogConfigs(Collections.singletonList(logStreamConfig));
+
+    SingerSettings.setSingerConfig(singerConfig);
+    SingerSettings.getOrCreateFileSystemMonitor("");
+    LogStreamManager.initializeLogStreams();
+
+    Collection<LogStream> logStreams = LogStreamManager.getLogStreams();
+    assertEquals(NUM_FILES, logStreams.size());
+    for (File f : created) {
+      f.delete();
+    }
+  }
 }

--- a/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/S3WriterTest.java
@@ -81,6 +81,8 @@ public class S3WriterTest extends SingerTestBase {
     if (testBaseDir.exists()) {
       FileUtils.deleteDirectory(testBaseDir);
     }
+    // reset hostname
+    SingerUtils.setHostname(SingerUtils.getHostname(), "-");
   }
 
 


### PR DESCRIPTION
This resolves a problem where Singer attempts to initialize logstreams for watermark files when the regex in the logstream configuration isn't left-bounded. For example if we have a regex: `.*test.*` and in the directory we have the following files: 

```
.singer.my_logstream.test_001  <---- the watermark file
test_001 <---- the logfile
```

Singer will try to initialize logstreams for both files, resulting in a third watermark that tracks the watermark file:

```
.singer.my_logstream..singer.my_logstream.test_001 <---- unwanted watermark file
.singer.my_logstream.test_001  <---- watermark file
test_001 <---- logfile
```

In some cases when filenames are long, the processor won't be able to persist progress onto the unwanted watermark files due to filename too long exceptions.

Test Plan:

Added unit tests and tested in dev environment, as well as in kubernetes since its bound to happen more often there