### PR TITLE
Add simple regex-based message filtering to text reader

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -72,7 +72,9 @@ struct TextReaderConfig {
   // ability to trim trailing new line character
   9: optional bool trimTailingNewlineCharacter = false;
   // custom environment variables to be injected into text logs
-  10:optional map<string, binary> environmentVariables;
+  10: optional map<string, binary> environmentVariables;
+  // Regex used to filter out messaqges that do not match the regex.
+  11: optional string filterMessageRegex;
 }
 
 struct LogStreamReaderConfig {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -102,6 +102,8 @@ public class SingerConfigDef {
   public static final String PROCESS_BATCH_SIZE = "batchSize";
   public static final String SKIP_DRAINING = "skipDraining";
 
+  public static final String TEXT_READER_FILTER_MESSAGE_REGEX = "filterMessageRegex";
+
   public static final String BUCKET = "bucket";
   public static final String KEY_FORMAT = "keyFormat";
   public static final String MAX_FILE_SIZE_MB = "maxFileSizeMB";

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -302,6 +302,20 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
     return result;
   }
 
+  /**
+   * Check if message should be skipped based on injected headers. If the message contains
+   * the header "skipMessage", the message should be skipped. Note that the value is irrelevant
+   * since the readers should only inject the header if the message should be skipped.
+   *
+   * @param logMessageAndPosition
+   * @return true if logMessageAndPosition contains skipMessageHeader, else otherwise.
+   */
+  protected boolean shouldSkipMessage(LogMessageAndPosition logMessageAndPosition) {
+    return logMessageAndPosition != null && logMessageAndPosition.getInjectedHeaders() != null
+        && logMessageAndPosition.getInjectedHeaders().containsKey("skipMessage")
+        && logMessageAndPosition.getInjectedHeaders().get("skipMessage").array().length == 0;
+  }
+
   @Override
   public void run() {
     long logMessagesProcessed = -1;

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -26,6 +26,7 @@ import com.pinterest.singer.common.SingerMetrics;
 import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.config.Decider;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.reader.LogFileReader;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.LogFileAndPath;
 import com.pinterest.singer.thrift.LogMessage;
@@ -312,8 +313,8 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
    */
   protected boolean shouldSkipMessage(LogMessageAndPosition logMessageAndPosition) {
     return logMessageAndPosition != null && logMessageAndPosition.getInjectedHeaders() != null
-        && logMessageAndPosition.getInjectedHeaders().containsKey("skipMessage")
-        && logMessageAndPosition.getInjectedHeaders().get("skipMessage").array().length == 0;
+        && logMessageAndPosition.getInjectedHeaders().containsKey(LogFileReader.SKIP_MESSAGE_HEADER_KEY)
+        && logMessageAndPosition.getInjectedHeaders().get(LogFileReader.SKIP_MESSAGE_HEADER_KEY).array().length == 0;
   }
 
   @Override

--- a/singer/src/main/java/com/pinterest/singer/reader/LogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/LogFileReader.java
@@ -26,6 +26,11 @@ import java.io.Closeable;
 public interface LogFileReader extends Closeable {
 
   /**
+   * Readers should inject this header to signal processor to skip a message
+   */
+  String SKIP_MESSAGE_HEADER_KEY = "skipMessage";
+
+  /**
    * Read a LogMessage with its position.
    *
    * @return LogMessage and its position in the LogStream. Return null if we reach the end of the

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.reader;
 
 import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.thrift.LogMessageAndPosition;
@@ -26,6 +27,7 @@ import com.pinterest.singer.utils.SingerUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import org.apache.thrift.TSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +56,7 @@ public class TextLogFileReader implements LogFileReader {
   private final String prependFieldDelimiter;
   private final TSerializer serializer;
   private final TextMessageReader textMessageReader;
+  private final Pattern filterMessageRegex;
   private ByteBuffer maxBuffer;
 
   // The text log message format, can be TextMessage, or String;
@@ -74,6 +77,7 @@ public class TextLogFileReader implements LogFileReader {
                            int maxMessageSize,
                            int numMessagesPerLogMessage,
                            Pattern messageStartPattern,
+                           Pattern filterMessageRegex,
                            TextLogMessageType messageType,
                            boolean prependTimestamp,
                            boolean prependHostName,
@@ -109,6 +113,7 @@ public class TextLogFileReader implements LogFileReader {
     int capacity = (maxMessageSize * numMessagesPerLogMessage) + MAX_BUFFER_HEADROOM;
     this.maxBuffer = ByteBuffer.allocate(capacity);
     this.trimTailingNewlineCharacter = trimTailingNewlineCharacter;
+    this.filterMessageRegex = filterMessageRegex;
 
     // Make sure the path is still associated with the LogFile.
     // This can happen when the path is reused for another LogFile during log
@@ -135,12 +140,17 @@ public class TextLogFileReader implements LogFileReader {
 
     try {
       TextMessageReader.resetByteBuffer(maxBuffer);
-
+      boolean skipLogMessage = false;
       for (int i = 0; i < numMessagesPerLogMessage; ++i) {
         ByteBuffer message = textMessageReader.readMessage(true);
         // If no message in the file, break.
         if (message == null) {
           break;
+        }
+        // If the message does not match the filter regex, mark it to be skipped.
+        if (filterMessageRegex != null && !filterMessageRegex.matcher(
+            TextMessageReader.bufToString(message)).matches()) {
+          skipLogMessage = true;
         }
         String prependStr = "";
         if (prependTimestamp) {
@@ -189,7 +199,16 @@ public class TextLogFileReader implements LogFileReader {
       // Get the next message's byte offset
       LogPosition position = new LogPosition(logFile, textMessageReader.getByteOffset());
       LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, position);
-      logMessageAndPosition.setInjectedHeaders(headers);
+      // Inject an immutable map with a single skipMessage header so that processors can skip this message
+      // we initialize it here in case environmentVariableInjection is disabled
+      if (skipLogMessage) {
+        logMessageAndPosition.setInjectedHeaders(
+            ImmutableMap.of("skipMessage", ByteBuffer.wrap(new byte[0])));
+        OpenTsdbMetricConverter.incr("singer.reader.text.filtered_messages",
+            "logName=" + logStream.getSingerLog().getSingerLogConfig().getName());
+      } else {
+        logMessageAndPosition.setInjectedHeaders(headers);
+      }
       return logMessageAndPosition;
     } catch (Exception e) {
       LOG.error("Caught exception when read a log message from log file: " + logFile, e);

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -199,11 +199,11 @@ public class TextLogFileReader implements LogFileReader {
       // Get the next message's byte offset
       LogPosition position = new LogPosition(logFile, textMessageReader.getByteOffset());
       LogMessageAndPosition logMessageAndPosition = new LogMessageAndPosition(logMessage, position);
-      // Inject an immutable map with a single skipMessage header so that processors can skip this message
+      // Inject an immutable map with a single "skipMessage" header so that processors can skip this message
       // we initialize it here in case environmentVariableInjection is disabled
       if (skipLogMessage) {
         logMessageAndPosition.setInjectedHeaders(
-            ImmutableMap.of("skipMessage", ByteBuffer.wrap(new byte[0])));
+            ImmutableMap.of(LogFileReader.SKIP_MESSAGE_HEADER_KEY, ByteBuffer.wrap(new byte[0])));
         OpenTsdbMetricConverter.incr("singer.reader.text.filtered_messages",
             "logName=" + logStream.getSingerLog().getSingerLogConfig().getName());
       } else {

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
@@ -59,6 +59,8 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
           readerConfig.getMaxMessageSize(),
           readerConfig.getNumMessagesPerLogMessage(),
           Pattern.compile(readerConfig.getMessageStartRegex(), Pattern.UNIX_LINES),
+          readerConfig.getFilterMessageRegex() != null ? Pattern.compile(
+              readerConfig.getFilterMessageRegex(), Pattern.DOTALL) : null,
           readerConfig.getTextLogMessageType(),
           readerConfig.isPrependTimestamp(),
           readerConfig.isPrependHostname(),

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -1203,15 +1203,18 @@ public class LogConfigUtils {
       }
     }
 
-    if (textReaderConfiguration.containsKey("filterMessageRegex")) {
+    if (textReaderConfiguration.containsKey(SingerConfigDef.TEXT_READER_FILTER_MESSAGE_REGEX)) {
       try {
-        String filterMessageRegex = textReaderConfiguration.getString("filterMessageRegex");
+        String
+            filterMessageRegex =
+            textReaderConfiguration.getString(SingerConfigDef.TEXT_READER_FILTER_MESSAGE_REGEX);
         if (!filterMessageRegex.isEmpty()) {
           Pattern.compile(filterMessageRegex);
           config.setFilterMessageRegex(filterMessageRegex);
         }
       } catch (PatternSyntaxException ex) {
-        throw new ConfigurationException("Bad filterMessageRegex", ex);
+        throw new ConfigurationException(
+            "Failed to compile " + SingerConfigDef.TEXT_READER_FILTER_MESSAGE_REGEX, ex);
       }
     }
 

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -1203,6 +1203,18 @@ public class LogConfigUtils {
       }
     }
 
+    if (textReaderConfiguration.containsKey("filterMessageRegex")) {
+      try {
+        String filterMessageRegex = textReaderConfiguration.getString("filterMessageRegex");
+        if (!filterMessageRegex.isEmpty()) {
+          Pattern.compile(filterMessageRegex);
+          config.setFilterMessageRegex(filterMessageRegex);
+        }
+      } catch (PatternSyntaxException ex) {
+        throw new ConfigurationException("Bad filterMessageRegex", ex);
+      }
+    }
+
     config.setPrependTimestamp(false);
     if (textReaderConfiguration.containsKey("prependTimestamp")) {
       String prependTimestampStr = textReaderConfiguration.getString("prependTimestamp");

--- a/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
@@ -126,8 +126,8 @@ public class TestTextLogFileReader extends SingerTestBase {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
       if (i % 2 == 0) {
         assertEquals(customInfoMessage, new String(log.getLogMessage().getMessage()));
-        assertTrue(log.getInjectedHeaders().containsKey("skipMessage"));
-        assertEquals(0, log.getInjectedHeaders().get("skipMessage").array().length);
+        assertTrue(log.getInjectedHeaders().containsKey(LogFileReader.SKIP_MESSAGE_HEADER_KEY));
+        assertEquals(0, log.getInjectedHeaders().get(LogFileReader.SKIP_MESSAGE_HEADER_KEY).array().length);
       } else {
         assertEquals(customErrorMessage, new String(log.getLogMessage().getMessage()));
         assertEquals(null, log.getInjectedHeaders());

--- a/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
+++ b/singer/src/test/java/com/pinterest/singer/reader/TestTextLogFileReader.java
@@ -50,7 +50,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     LogFile logFile = new LogFile(inode);
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
     LogFileReader reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 1,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, null, null,
+        Pattern.compile("^.*$"), null, TextLogMessageType.PLAIN_TEXT, false, false, true, null, null,
         null, null);
     for (int i = 0; i < 100; i++) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
@@ -70,7 +70,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     LogFile logFile = new LogFile(inode);
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
     LogFileReader reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 1,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, true, false, hostname, "n/a",
+        Pattern.compile("^.*$"), null, TextLogMessageType.PLAIN_TEXT, false, true, false, hostname, "n/a",
         delimiter, null);
     for (int i = 0; i < 100; i++) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
@@ -91,7 +91,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     LogFile logFile = new LogFile(inode);
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
     LogFileReader reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 2,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, null, "n/a",
+        Pattern.compile("^.*$"), null, TextLogMessageType.PLAIN_TEXT, false, false, true, null, "n/a",
         null, null);
     for (int i = 0; i < 100; i = i + 2) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
@@ -99,6 +99,52 @@ public class TestTextLogFileReader extends SingerTestBase {
           new String(log.getLogMessage().getMessage()));
     }
     assertNull(reader.readLogMessageAndPosition());
+    reader.close();
+  }
+
+  @Test
+  public void testReadMessagesWithFilterRegexEnabled() throws Exception {
+    String path = FilenameUtils.concat(getTempPath(), "test_filtered.log");
+    String customInfoMessage = "2024-09-26 00:00:00,000 [Thread-1] (com.pinterest.singer.TestClass:120) INFO Sample info message\n";
+    String customErrorMessage = "2024-09-26 00:00:00,000 [Thread-1] (com.pinterest.singer.TestClass:120) ERROR Sample error message\n";
+    String filterRegex = ".*\\bERROR\\b.*";
+
+    TextLogger logger = new TextLogger(path);
+    for (int i = 0; i < 100; i++) {
+      logger.logText(customInfoMessage);
+      logger.logText(customErrorMessage);
+    }
+
+    long inode = SingerUtils.getFileInode(SingerUtils.getPath(path));
+    LogFile logFile = new LogFile(inode);
+    LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
+    LogFileReader reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 1,
+        Pattern.compile("^.*$"), Pattern.compile(filterRegex, Pattern.DOTALL),
+        TextLogMessageType.PLAIN_TEXT, false, false, false, null, null,
+        null, null);
+    for (int i = 0; i < 100; i++) {
+      LogMessageAndPosition log = reader.readLogMessageAndPosition();
+      if (i % 2 == 0) {
+        assertEquals(customInfoMessage, new String(log.getLogMessage().getMessage()));
+        assertTrue(log.getInjectedHeaders().containsKey("skipMessage"));
+        assertEquals(0, log.getInjectedHeaders().get("skipMessage").array().length);
+      } else {
+        assertEquals(customErrorMessage, new String(log.getLogMessage().getMessage()));
+        assertEquals(null, log.getInjectedHeaders());
+      }
+    }
+    reader.close();
+
+    filterRegex = ".*\\bThread-1\\b.*";
+    reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 1,
+        Pattern.compile("^.*$"), Pattern.compile(filterRegex, Pattern.DOTALL),
+        TextLogMessageType.PLAIN_TEXT, false, false, false, "test", "test-az",
+        null, new HashMap<>());
+    // No messages should have skipMessageHeader
+    for (int i = 0; i < 100; i++) {
+      LogMessageAndPosition log = reader.readLogMessageAndPosition();
+      assertFalse(log.getInjectedHeaders().containsKey("skipMessage"));
+    }
     reader.close();
   }
 
@@ -111,7 +157,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     LogFile logFile = new LogFile(inode);
     LogStream logStream = new LogStream(new SingerLog(new SingerLogConfig()), "test");
     LogFileReader reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 2,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, "host", "n/a", null,
+        Pattern.compile("^.*$"), null, TextLogMessageType.PLAIN_TEXT, false, false, true, "host", "n/a", null,
         new HashMap<>(ImmutableMap.of("test", ByteBuffer.wrap("value".getBytes()))));
     for (int i = 0; i < 100; i = i + 2) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();
@@ -127,7 +173,7 @@ public class TestTextLogFileReader extends SingerTestBase {
     reader.close();
     
     reader = new TextLogFileReader(logStream, logFile, path, 0, 8192, 102400, 2,
-        Pattern.compile("^.*$"), TextLogMessageType.PLAIN_TEXT, false, false, true, "host", "n/a", null,
+        Pattern.compile("^.*$"), null, TextLogMessageType.PLAIN_TEXT, false, false, true, "host", "n/a", null,
         null);
     for (int i = 0; i < 100; i = i + 2) {
       LogMessageAndPosition log = reader.readLogMessageAndPosition();


### PR DESCRIPTION
Introducing the config `filterMessageRegex` so that only messages that match the pattern provided will be returned to the processor. This does not modify the existing TextMessageReader logic, instead we leverage the headers as a DOT so that the processor knows that message should be skipped if it contains the special header `skipMessage`. The skipping logic is the same as the decider based sampling logic.