### PR TITLE
Add message transformer interface

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -84,6 +84,32 @@ struct LogStreamReaderConfig {
 }
 
 /**
+  * Transforms related configurations
+  *
+  * REGEX_BASED_MODIFIER:  A regex based modifier that modifies the log message based on the regex
+  *                        and the modified message format.
+ **/
+enum TransformType {
+  REGEX_BASED_MODIFIER = 0
+}
+
+struct RegexBasedModifierConfig {
+  // The regex to match the log message.
+  1: required string regex;
+  // The modified message format. The regex captured groups can be referenced by $1, $2, etc.
+  2: required string modifiedMessageFormat;
+  // The encoding of the log message.
+  3: optional string encoding = "UTF-8";
+  // Append a newline to the end of the modified message.
+  4: optional bool appendNewLine = true;
+}
+
+struct MessageTransformerConfig {
+  1: required TransformType type;
+  2: optional RegexBasedModifierConfig regexBasedModifierConfig;
+}
+
+/**
  * KAFKA:  kafka writer that distributes messages to topic partitions based on
  *         partititioner. The default partitioner does random distribution among
  *         all partitions of a topic. Using a writer threadpool underneath, we can
@@ -250,6 +276,10 @@ struct SingerLogConfig {
    *  this log will be skipped directly when draining is enabled
    */
   14: optional bool skipDraining = false;
+  /**
+   *  Configuration to transform log message
+   */
+  15: optional MessageTransformerConfig messageTransformerConfig;
 }
 
 /**

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -104,6 +104,11 @@ public class SingerConfigDef {
 
   public static final String TEXT_READER_FILTER_MESSAGE_REGEX = "filterMessageRegex";
 
+  public static final String RBM_REGEX = "regex";
+  public static final String RBM_MODIFIED_MESSAGE_FORMAT = "modifiedMessageFormat";
+  public static final String RBM_ENCODING = "encoding";
+  public static final String RBM_APPEND_NEW_LINE = "appendNewLine";
+
   public static final String BUCKET = "bucket";
   public static final String KEY_FORMAT = "keyFormat";
   public static final String MAX_FILE_SIZE_MB = "maxFileSizeMB";

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -84,6 +84,9 @@ public class SingerMetrics {
   public static final String NUM_ABORTED_TRANSACTIONS = SINGER_WRITER + "num_aborted_transactions";
   public static final String NUM_KAFKA_PRODUCERS = SINGER_WRITER + "num_kafka_producers";
 
+  public static final String SINGER_TRANSFORMER = SINGER_PREIX + "transformer.";
+  public static final String REGEX_BASED_MODIFIER = SINGER_TRANSFORMER + "regex_based_modifier.";
+
   public static final String KUBE_PREFIX           = SINGER_PREIX + "kube.";
   public static final String KUBE_API_ERROR        = KUBE_PREFIX  + "api_error";
   public static final String KUBE_SERVICE_ERROR = KUBE_PREFIX + "kubeservice_thread_error";

--- a/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/DefaultLogMonitor.java
@@ -31,6 +31,7 @@ import com.pinterest.singer.processor.MemoryEfficientLogStreamProcessor;
 import com.pinterest.singer.reader.DefaultLogStreamReader;
 import com.pinterest.singer.reader.TextLogFileReaderFactory;
 import com.pinterest.singer.reader.ThriftLogFileReaderFactory;
+import com.pinterest.singer.thrift.configuration.MessageTransformerConfig;
 import com.pinterest.singer.thrift.configuration.NoOpWriteConfig;
 import com.pinterest.singer.thrift.configuration.S3WriterConfig;
 import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
@@ -280,7 +281,8 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
                                                       LogStream logStream)
       throws ConfigurationException, LogStreamReaderException, LogStreamWriterException {
     LogStreamReader reader =
-        createLogStreamReader(logStream, singerLogConfig.getLogStreamReaderConfig());
+        createLogStreamReader(logStream, singerLogConfig.getLogStreamReaderConfig(),
+            singerLogConfig.getMessageTransformerConfig());
     LogStreamWriter writer =
         createLogStreamWriter(logStream, singerLogConfig.getLogStreamWriterConfig());
 
@@ -326,9 +328,11 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
    * @throws Exception when fail to create the reader for the LogStream.
    */
   protected LogStreamReader createLogStreamReader(LogStream logStream,
-                                                LogStreamReaderConfig readerConfig)
+                                                  LogStreamReaderConfig readerConfig,
+                                                  MessageTransformerConfig messageTransformerConfig)
       throws LogStreamReaderException {
     switch (readerConfig.getType()) {
+      // No transforms available for thrift logs yet
       case THRIFT:
         ThriftReaderConfig thriftReaderConfig = readerConfig.getThriftReaderConfig();
         return new DefaultLogStreamReader(logStream,
@@ -337,7 +341,7 @@ public class DefaultLogMonitor implements LogMonitor, Runnable {
       case TEXT:
         TextReaderConfig textReaderConfig = readerConfig.getTextReaderConfig();
         return new DefaultLogStreamReader(logStream,
-            new TextLogFileReaderFactory(textReaderConfig));
+            new TextLogFileReaderFactory(textReaderConfig, messageTransformerConfig));
 
       default:
         throw new LogStreamReaderException("Unsupported log reader type");

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReaderFactory.java
@@ -18,6 +18,7 @@ package com.pinterest.singer.reader;
 import com.pinterest.singer.common.LogStream;
 import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.thrift.LogFile;
+import com.pinterest.singer.thrift.configuration.MessageTransformerConfig;
 import com.pinterest.singer.thrift.configuration.TextReaderConfig;
 import com.pinterest.singer.utils.LogFileUtils;
 import com.pinterest.singer.utils.SingerUtils;
@@ -37,9 +38,11 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(TextLogFileReaderFactory.class);
   private final TextReaderConfig readerConfig;
+  private final MessageTransformerConfig messageTransformerConfig;
 
-  public TextLogFileReaderFactory(TextReaderConfig readerConfig) {
+  public TextLogFileReaderFactory(TextReaderConfig readerConfig, MessageTransformerConfig messageTransformerConfig) {
     this.readerConfig = Preconditions.checkNotNull(readerConfig);
+    this.messageTransformerConfig = messageTransformerConfig;
   }
 
   @SuppressWarnings("resource")
@@ -70,7 +73,8 @@ public class TextLogFileReaderFactory implements LogFileReaderFactory {
           readerConfig.getPrependFieldDelimiter(),
           readerConfig.getEnvironmentVariables() != null
           ? new HashMap<>(readerConfig.getEnvironmentVariables())
-          : null);
+          : null,
+          messageTransformerConfig);
     } catch (LogFileReaderException e) {
       LOG.warn("Exception in getLogFileReader", e);
       long inode = logFile.getInode();

--- a/singer/src/main/java/com/pinterest/singer/transforms/MessageTransformer.java
+++ b/singer/src/main/java/com/pinterest/singer/transforms/MessageTransformer.java
@@ -1,0 +1,16 @@
+package com.pinterest.singer.transforms;
+
+/**
+ * Represents a message transformer that can be used by LogFileReaders or other components to
+ * transform messages.
+ */
+public interface MessageTransformer<T> {
+
+  /**
+   * Transform the message.
+   *
+   * @param message the message to transform.
+   * @return the transformed message.
+   */
+  public T transform(T message);
+}

--- a/singer/src/main/java/com/pinterest/singer/transforms/MessageTransformerFactory.java
+++ b/singer/src/main/java/com/pinterest/singer/transforms/MessageTransformerFactory.java
@@ -1,0 +1,39 @@
+package com.pinterest.singer.transforms;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.thrift.configuration.MessageTransformerConfig;
+import com.pinterest.singer.thrift.configuration.RegexBasedModifierConfig;
+import com.pinterest.singer.thrift.configuration.TransformType;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MessageTransformerFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessageTransformerFactory.class);
+
+  public static MessageTransformer getTransformer(MessageTransformerConfig transformerConfig, LogStream logStream)
+      throws IllegalArgumentException {
+    if (transformerConfig == null) {
+      return null;
+    }
+    TransformType transformType = transformerConfig.getType();
+    MessageTransformer transformer;
+    try {
+      switch (transformType) {
+        case REGEX_BASED_MODIFIER:
+          RegexBasedModifierConfig regexBasedModifierConfig = transformerConfig.getRegexBasedModifierConfig();
+          transformer = new RegexBasedModifier(regexBasedModifierConfig, logStream);
+          break;
+        default:
+          transformer = null;
+      }
+    } catch (ConfigurationException e) {
+      LOG.warn("Could not initialize transformer {} for log stream {}, it will be disabled", transformType,
+          logStream.getSingerLog().getSingerLogConfig().getName(), e);
+      transformer = null;
+    }
+    return transformer;
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/transforms/RegexBasedModifier.java
+++ b/singer/src/main/java/com/pinterest/singer/transforms/RegexBasedModifier.java
@@ -1,0 +1,105 @@
+package com.pinterest.singer.transforms;
+
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.thrift.configuration.RegexBasedModifierConfig;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.configuration.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A message transformer that modifies messages based on a regex pattern.
+ * This transformer uses a regex pattern to match a message and then replaces the matched groups in
+ * the message with the specified format.
+ */
+public class RegexBasedModifier implements MessageTransformer<ByteBuffer> {
+  private static final Logger LOG = LoggerFactory.getLogger(RegexBasedModifier.class);
+  private final LogStream logStream;
+  private final String logName;
+  private final Pattern regex;
+  private final Charset encoding;
+  private final String messageFormat;
+  private final boolean appendNewline;
+
+  public RegexBasedModifier(RegexBasedModifierConfig config, LogStream logStream)
+      throws ConfigurationException {
+    this.messageFormat = Preconditions.checkNotNull(config.getModifiedMessageFormat());
+    this.encoding = Charset.forName(config.getEncoding());
+    this.logStream = logStream;
+    this.logName = logStream.getSingerLog().getSingerLogConfig().getName();
+    this.appendNewline = config.isAppendNewLine();
+    try {
+      this.regex = Pattern.compile(config.getRegex());
+    } catch (PatternSyntaxException e) {
+      throw new ConfigurationException("Invalid modifier regex ", e);
+    }
+  }
+
+  /**
+   * Transforms a message based on the regex pattern and message format.
+   * If the message does not match the regex pattern or an exception occurs, the original message
+   * is returned so that we don't block the log stream. If the message matches the regex pattern,
+   * the matched groups are replaced in the message format, each group should be referenced in the
+   * modified message format using $1, $2, etc.
+   *
+   * @param message the message to transform.
+   * @return the transformed message or the original message if no transformation occurred.
+   */
+  @Override
+  public ByteBuffer transform(ByteBuffer message) {
+    String messageString = bufferToString(message);
+    Matcher matcher = regex.matcher(messageString);
+    if (!matcher.find()) {
+      LOG.debug("[RegexParser] Message " + messageString + " did not match regex: " + regex);
+      OpenTsdbMetricConverter.incr(SingerMetrics.REGEX_BASED_MODIFIER + "no_message_match",
+          "logName=" + "file=" + logStream.getFileNamePrefix());
+      return message;
+    }
+    try {
+      Map<String, String> groupMap = new HashMap<>();
+      for (int i = 1; i <= matcher.groupCount(); i++) {
+        groupMap.put("$" + i, matcher.group(i));
+        LOG.debug("Group " + i + ": " + matcher.group(i));
+      }
+      StringBuilder result = new StringBuilder(messageFormat);
+      groupMap.forEach((groupIndex, value) -> {
+        int start;
+        while ((start = result.indexOf(groupIndex)) != -1) {
+          result.replace(start, start + groupIndex.length(), value);
+        }
+      });
+      if (appendNewline) result.append("\n");
+      OpenTsdbMetricConverter.incr(SingerMetrics.REGEX_BASED_MODIFIER + "success",
+          "logName=" + logName, "file=" + logStream.getFileNamePrefix());
+      return ByteBuffer.wrap(result.toString().getBytes(encoding));
+    } catch (Exception e) {
+      LOG.warn("Failed to transform message in log stream {}, returning raw message.",
+          logName, e);
+      OpenTsdbMetricConverter.incr(SingerMetrics.REGEX_BASED_MODIFIER + "failures",
+          "logName=" + logName, "file=" + logStream.getFileNamePrefix());
+      return message;
+    }
+  }
+
+  /**
+   * Converts a ByteBuffer to a String using the specified encoding.
+   *
+   * @param message
+   * @return the String representation of the ByteBuffer.
+   */
+  private String bufferToString(ByteBuffer message) {
+    String string = new String(message.array(), 0, message.limit(), encoding);
+    return string;
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
@@ -492,7 +492,7 @@ public class TestMemoryEfficientLogStreamProcessor extends com.pinterest.singer.
     textReaderConfig.setTextLogMessageType(TextLogMessageType.PLAIN_TEXT);
     LogStreamReader logStreamReader = new DefaultLogStreamReader(
         logStream,
-        new TextLogFileReaderFactory(textReaderConfig));
+        new TextLogFileReaderFactory(textReaderConfig, null));
     MemoryEfficientLogStreamProcessor processor = new MemoryEfficientLogStreamProcessor(logStream,
         null, logStreamReader, writer, processorBatchSize, processingIntervalInMillisMin,
         processingIntervalInMillisMax, processingTimeSliceInMilliseconds, logRetentionInSecs, false);

--- a/singer/src/test/java/com/pinterest/singer/transforms/RegexBasedModifierTest.java
+++ b/singer/src/test/java/com/pinterest/singer/transforms/RegexBasedModifierTest.java
@@ -1,0 +1,67 @@
+package com.pinterest.singer.transforms;
+
+import com.pinterest.singer.SingerTestBase;
+import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerLog;
+import com.pinterest.singer.thrift.configuration.MessageTransformerConfig;
+import com.pinterest.singer.thrift.configuration.RegexBasedModifierConfig;
+import com.pinterest.singer.thrift.configuration.SingerLogConfig;
+import com.pinterest.singer.thrift.configuration.TransformType;
+
+import com.google.common.base.Charsets;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class RegexBasedModifierTest extends SingerTestBase {
+
+  MessageTransformerConfig messageTransformerConfig;
+  RegexBasedModifierConfig regexBasedModifierConfig;
+  LogStream logStream;
+
+  @Override
+  public void setUp() {
+    messageTransformerConfig = new MessageTransformerConfig();
+    messageTransformerConfig.setType(TransformType.REGEX_BASED_MODIFIER);
+    regexBasedModifierConfig = new RegexBasedModifierConfig();
+    SingerLog singerLog = new SingerLog(
+        new SingerLogConfig("test", "test_dir", "test.log", null, null, null));
+    logStream = new LogStream(singerLog, "test.log");
+  }
+
+  @Override
+  public void tearDown() {
+    messageTransformerConfig = null;
+    regexBasedModifierConfig = null;
+  }
+
+  @Test
+  public void testSimpleLogExtraction() throws Exception {
+    regexBasedModifierConfig.setRegex("\\[(?<thread>.*?)\\] (?<message>.*)");
+    regexBasedModifierConfig.setModifiedMessageFormat("{Thread: \"$1\", Log: \"$2\"}");
+    regexBasedModifierConfig.setEncoding("UTF-8");
+    regexBasedModifierConfig.setAppendNewLine(false);
+    messageTransformerConfig.setRegexBasedModifierConfig(regexBasedModifierConfig);
+    RegexBasedModifier regexBasedModifier = new RegexBasedModifier(regexBasedModifierConfig, logStream);
+
+    String logMessage = "[SingerMain] Starting Singer...";
+    ByteBuffer logMessageBuf = regexBasedModifier.transform(ByteBuffer.wrap(logMessage.getBytes()));
+
+    String expected = "{Thread: \"SingerMain\", Log: \"Starting Singer...\"}";
+    assertEquals(expected, new String(logMessageBuf.array(), 0, logMessageBuf.limit(), Charsets.UTF_8));
+  }
+
+  @Test
+  public void testNoRegexMatch() throws Exception {
+    regexBasedModifierConfig.setRegex("singer_(\\d+).log");
+    regexBasedModifierConfig.setModifiedMessageFormat("singer log number: $1");
+    regexBasedModifierConfig.setEncoding("UTF-8");
+    messageTransformerConfig.setRegexBasedModifierConfig(regexBasedModifierConfig);
+    RegexBasedModifier regexBasedModifier = new RegexBasedModifier(regexBasedModifierConfig, logStream);
+
+    String logMessage = "This is a sample message";
+    ByteBuffer logMessageBuf = ByteBuffer.wrap(logMessage.getBytes());
+    assertEquals(logMessageBuf, regexBasedModifier.transform(logMessageBuf));
+  }
+
+}

--- a/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
@@ -51,6 +51,7 @@ import com.pinterest.singer.thrift.configuration.KafkaProducerConfig;
 import com.pinterest.singer.thrift.configuration.LogStreamProcessorConfig;
 import com.pinterest.singer.thrift.configuration.MemqWriterConfig;
 import com.pinterest.singer.thrift.configuration.RealpinWriterConfig;
+import com.pinterest.singer.thrift.configuration.RegexBasedModifierConfig;
 import com.pinterest.singer.thrift.configuration.S3WriterConfig;
 import com.pinterest.singer.thrift.configuration.SamplingType;
 import com.pinterest.singer.thrift.configuration.TextReaderConfig;
@@ -466,5 +467,23 @@ public class TestLogConfigUtils {
     assertEquals(100, s3WriterConfig.getMaxFileSizeMB());
     assertEquals(30, s3WriterConfig.getMinUploadTimeInSeconds());
     assertEquals(10, s3WriterConfig.getMaxRetries());
+  }
+
+  @Test
+  public void testRegexTransformerConfigurations() throws Exception {
+    String
+        config =
+        "type=regex_based_modifier\n"
+            + "modifiedMessageFormat={log_level: $2\\, message: $4\\, timestamp: $1}\n"
+            + "regex_based_modifier.encoding=UTF-8\n"
+            + "regex=some_regex\n";
+    PropertiesConfiguration conf = new PropertiesConfiguration();
+    conf.load(new ByteArrayInputStream(config.getBytes()));
+
+    RegexBasedModifierConfig
+        regexBasedModifierConfig =
+        LogConfigUtils.parseRegexBasedModifierConfig(conf);
+
+    assertNotNull(regexBasedModifierConfig);
   }
 }


### PR DESCRIPTION
Introducing a message transformer interface for `LogFileReaders`, enabling the transformation of messages before they are forwarded to `LogStreamProcessors`. The desired transformer along its configuration can be defined within a LogStream configuration file as follows:

```
# Configuration for transformer
transformer.type=regex_based_modifier
transformer.regex_based_modifier.regex=(?s)^(.+?) (INFO|ERROR|OFF|DEBUG|SEVERE|WARN) (null) (.*)$
transformer.regex_based_modifier.modifiedMessageFormat={log_level: $2, message: $4, timestamp: $1}
transformer.regex_based_modifier.appendNewLine=true
```

Please note that configuring message transformers is optional, and only one transformer can be applied per log stream. Currently, we are introducing a single transformer: `RegexBasedModifier`. This transformer uses a regular expression to extract fields from a message and reconstructs it based on the modifiedMessageFormat specification. Additionally, transformers are intentionally disabled for ThriftReaders, as altering Thrift messages would be too expensive.

For example, with the configuration shown above, the following message:

```
2024-11-15 23:59:37 OFF null 7301524e-6de0-4b01-87b8
```
would be transformed to:

```
{log_level: OFF, message: 7301524e-6de0-4b01-87b8, timestamp: 2024-11-15 23:59:37}
```