### PR TITLE
Enhance s3 object key formatting

### DIFF
--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -91,6 +91,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>


### PR DESCRIPTION
Enhance the s3Key building function:

1. Utilize `StringSubstitutor` from apache-commons library for token replacement
2. Add Year, Month, Day, Hour, Minute, Seconds to default tokens for more granular date/time prefixing
3. Allow environment variables to be replaced into s3Key
4. Change formatting for tokens:
        - `%{}` will continue to be used for regex tokens
        - `{{}}` will now be used for default tokens
        - `${}` will be used for environment variables