### PR TITLE
Introduce s3 client manager and s3 uploaders

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -173,6 +173,10 @@ struct S3WriterConfig {
   // The S3 canned access control lists (ACLs) that can be applied to uploaded objects to determine their access permissions.
   // We don't set a default since some buckets don't allow setting canned ACLs.
   9: optional string cannedAcl;
+  // The uploader class to use for uploading objects to S3.
+  10: optional string uploaderClass = "com.pinterest.singer.writer.s3.PutObjectUploader";
+  // Region of the S3 bucket.
+  11: optional string region = "us-east-1";
 }
 
 enum RealpinObjectType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -109,6 +109,7 @@ public class SingerConfigDef {
   public static final String RBM_ENCODING = "encoding";
   public static final String RBM_APPEND_NEW_LINE = "appendNewLine";
 
+  // S3 writer config
   public static final String BUCKET = "bucket";
   public static final String KEY_FORMAT = "keyFormat";
   public static final String MAX_FILE_SIZE_MB = "maxFileSizeMB";
@@ -117,5 +118,7 @@ public class SingerConfigDef {
   public static final String MAX_RETRIES = "maxRetries";
   public static final String BUFFER_DIR = "bufferDir";
   public static final String CANNED_ACL = "cannedAcl";
+  public static final String UPLOADER_CLASS = "uploaderClass";
+  public static final String REGION = "region";
   public static final String NAMED_GROUP_PATTERN = "\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>";
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -56,6 +56,7 @@ import com.pinterest.singer.thrift.configuration.ThriftReaderConfig;
 import com.pinterest.singer.thrift.configuration.TransformType;
 import com.pinterest.singer.thrift.configuration.WriterType;
 
+import com.amazonaws.regions.Regions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -848,6 +849,25 @@ public class LogConfigUtils {
 
     if (writerConfiguration.containsKey(SingerConfigDef.BUFFER_DIR)) {
       config.setBufferDir(writerConfiguration.getString(SingerConfigDef.BUFFER_DIR));
+    }
+
+    if (writerConfiguration.containsKey(SingerConfigDef.UPLOADER_CLASS)) {
+      // check if class is valid
+      try {
+        Class.forName(writerConfiguration.getString(SingerConfigDef.UPLOADER_CLASS));
+      } catch (ClassNotFoundException e) {
+        throw new ConfigurationException("Invalid uploader class: " + writerConfiguration.getString(SingerConfigDef.UPLOADER_CLASS), e);
+      }
+      config.setUploaderClass(writerConfiguration.getString(SingerConfigDef.UPLOADER_CLASS));
+    }
+
+    if (writerConfiguration.containsKey(SingerConfigDef.REGION)) {
+      try {
+        Regions.fromName(writerConfiguration.getString(SingerConfigDef.REGION));
+      } catch (IllegalArgumentException e) {
+        throw new ConfigurationException("Invalid region provided: " + writerConfiguration.getString(SingerConfigDef.REGION), e);
+      }
+      config.setRegion(writerConfiguration.getString(SingerConfigDef.REGION));
     }
     return config;
   }

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3ClientManager.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3ClientManager.java
@@ -1,0 +1,80 @@
+package com.pinterest.singer.writer.s3;
+
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Singleton class that holds a region -> S3Client mapping for S3 client
+ * reuse and multi-region support.
+ */
+public class S3ClientManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3ClientManager.class);
+  private static S3ClientManager s3UploaderManagerInstance = null;
+
+  static {
+    S3ClientManager.getInstance();
+  }
+
+  public static S3ClientManager getInstance() {
+    if (s3UploaderManagerInstance == null) {
+      synchronized (S3ClientManager.class) {
+        if (s3UploaderManagerInstance == null) {
+          s3UploaderManagerInstance = new S3ClientManager();
+        }
+      }
+    }
+    return s3UploaderManagerInstance;
+  }
+
+  private ConcurrentHashMap<String, S3Client> s3ClientMap;
+
+  private S3ClientManager() {
+    s3ClientMap = new ConcurrentHashMap<>();
+  }
+
+  public static void shutdown() {
+    S3ClientManager.getInstance().closeS3Clients();
+  }
+
+  public S3Client get(String region) {
+    // For we only use the region as the key, in the future we can construct the key with more
+    // fields (e.g endpoint + region).
+    String key = region;
+    // We don't check if the client is closed here because S3 clients are meant to be
+    // long-lived objects, and they are not closed by the writers.
+    if (s3ClientMap.containsKey(key)) {
+      return s3ClientMap.get(key);
+    }
+    S3Client s3Client = S3Client.builder()
+        .region(Region.of(region))
+        .build();
+    s3ClientMap.put(key, s3Client);
+    OpenTsdbMetricConverter.addMetric(SingerMetrics.S3_WRITER + "num_clients", s3ClientMap.size());
+    return s3Client;
+  }
+
+  private void closeS3Clients() {
+    s3ClientMap.forEach((key, client) -> {
+      try {
+        client.close();
+      } catch (Exception e) {
+        LOG.error("Failed to close S3Client: {} ", key, e);
+      }
+    });
+  }
+
+  @VisibleForTesting
+  public Map<String, S3Client> getS3ClientMap() {
+    return s3ClientMap;
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3ObjectUpload.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3ObjectUpload.java
@@ -1,0 +1,25 @@
+package com.pinterest.singer.writer.s3;
+
+import java.io.File;
+
+/**
+ * Represents an S3 object upload.
+ */
+public class S3ObjectUpload {
+
+  private final String key;
+  private final File file;
+
+  public S3ObjectUpload(String key, File file) {
+    this.key = key;
+    this.file = file;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public File getFile() {
+    return file;
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Uploader.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Uploader.java
@@ -1,0 +1,31 @@
+package com.pinterest.singer.writer.s3;
+
+import com.pinterest.singer.thrift.configuration.S3WriterConfig;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+
+/**
+ * Abstract class for uploading S3 objects.
+ */
+public abstract class S3Uploader {
+  protected S3WriterConfig s3WriterConfig;
+  protected final ObjectCannedACL cannedAcl;
+  protected final String bucket;
+  protected S3Client s3Client;
+
+  public S3Uploader(S3WriterConfig s3WriterConfig, S3Client s3Client) {
+    this.s3WriterConfig = s3WriterConfig;
+    this.bucket = s3WriterConfig.getBucket();
+    this.cannedAcl = ObjectCannedACL.fromValue(s3WriterConfig.getCannedAcl());
+    this.s3Client = s3Client;
+  }
+
+  /**
+   * Uploads the given S3ObjectUpload to S3.
+   *
+   * @param s3ObjectUpload The S3ObjectUpload to upload.
+   * @return true if the upload was successful, false otherwise.
+   */
+  public abstract boolean upload(S3ObjectUpload s3ObjectUpload);
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/s3/S3ClientManagerTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/s3/S3ClientManagerTest.java
@@ -1,0 +1,23 @@
+package com.pinterest.singer.writer.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3ClientManagerTest {
+
+  @Test
+  public void testCreateMultipleS3Clients() {
+    S3ClientManager s3ClientManager = S3ClientManager.getInstance();
+    S3Client s3Client1 = s3ClientManager.get("us-east-1");
+    S3Client s3Client2 = s3ClientManager.get("us-west-2");
+    S3Client s3Client3 = s3ClientManager.get("us-east-1");
+    S3Client s3Client4 = s3ClientManager.get("us-west-2");
+    assertEquals(s3Client1, s3Client3);
+    assertEquals(s3Client2, s3Client4);
+    assertNotEquals(s3Client1, s3Client2);
+    assertEquals(2, s3ClientManager.getS3ClientMap().size());
+  }
+}

--- a/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.File;
 import java.io.IOException;
@@ -28,7 +27,6 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -78,7 +76,6 @@ public class S3WriterTest extends SingerTestBase {
     // reset hostname
     SingerUtils.setHostname(SingerUtils.getHostname(), "-");
   }
-
 
   @Test
   public void testSanitizeFileName() {


### PR DESCRIPTION
This PR enhances the S3writer in a few ways:

1. The uploading mechanism is now pluggable,  now uploaders have to extend `S3Uploader` class. This change simplifies the implementation of uploads to S3 using alternative APIs, such as `MultiPartUpload` or `TransferManager`. This ensures backwards compatibility so newer implementations are easier to roll out. New config is added to reference the uploader class: `optional string uploaderClass = "com.pinterest.singer.writer.s3.PutObjectUploader"`
2. Add support for uploading to buckets in different regions. The region needs to be specified when creating a new S3Client, this means one Singer instance can't upload to multiple buckets in different regions. To enable this, we introduce a new `S3ClientManager` which will create a new client per region. New S3Writer config for region: `optional string region = "us-east-1"`. Additionally, we remove the `S3Client.close()` call in S3Writer since clients are shared resources.
3. Use `S3ObjectUpload` to encapsulate an upload. Useful if metadata needs to be attached to each upload in the future
4. Rename `ObjectUploaderTask -> PutObjectUpolader` to match pluggable uploader class. Functionality remains the same