### PR TITLE
S3Writer  updates

### DIFF
--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -228,6 +228,11 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sts</artifactId>
+            <version>2.17.273</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
             <version>2.17.273</version>
         </dependency>

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Writer.java
@@ -421,10 +421,6 @@ public class S3Writer implements LogStreamWriter {
             "bucket=" + bucketName, "host=" + HOSTNAME, "logName=" + logName);
       }
     }
-
-    // We append a random UUID to the key to avoid collisions
-    // TODO: Provide configuration to disable this behavior if use case comes up
-    s3Key += "." + UUID.randomUUID().toString().substring(0, 8);
     LOG.info("Generated S3 object key: " + s3Key);
     return s3Key;
   }

--- a/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
@@ -196,7 +196,7 @@ public class S3WriterTest extends SingerTestBase {
 
     // Check last part of object key
     String[] keySuffixParts = objectKeyParts[3].split("\\.");
-    assertEquals(3, keySuffixParts.length);
+    assertEquals(2, keySuffixParts.length);
     assertEquals("test_log-0", keySuffixParts[0]);
     assertNotEquals("{{S}}", keySuffixParts[1]);
     assertEquals(2, keySuffixParts[1].length());


### PR DESCRIPTION
- Add STS dependency to allow S3Client to use Web Identity Tokens
- Remove default UUID append at the end of object key, users can add it if needed.