### PR TITLE
Enable dual mode

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -75,6 +75,7 @@ public class SingerConfigDef {
   public static final String KUBE_POLL_FREQUENCY_SECONDS = "pollFrequencyInSeconds";
   public static final String KUBE_POD_LOG_DIR = "podLogDirectory";
   public static final String KUBE_DEFAULT_DELETION_TIMEOUT = "defaultDeletionTimeoutInSeconds";
+  public static final String KUBE_IGNORE_POD_DIRECTORY = "ignorePodDirectory";
 
   public static final String SINGER_ADMIN_CONFIG_PREFIX = "singer.admin.";
   public static final String ADMIN_SOCKET_FILE = "socket.file";

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -290,6 +290,11 @@ public class LogConfigUtils {
       config.setDefaultDeletionTimeoutInSeconds(
           subsetConfig.getInt(SingerConfigDef.KUBE_DEFAULT_DELETION_TIMEOUT));
     }
+
+    if (subsetConfig.containsKey(SingerConfigDef.KUBE_IGNORE_POD_DIRECTORY)) {
+      config.setIgnorePodDirectory(
+          subsetConfig.getString(SingerConfigDef.KUBE_IGNORE_POD_DIRECTORY));
+    }
     return config;
   }
 


### PR DESCRIPTION
Parse 1singer.kubernetes.ignorePodDirectory` to enable dual mode (daemonset + sidecar) deployments in k8s