### PR TITLE
Add support for pod metadata header injection

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -337,6 +337,12 @@ struct KubeConfig {
   */
   6: optional string ignorePodDirectory = "";
 
+  /**
+  * List of pod metadata fields to include per Singer log, Singer will not
+  * track any pod metadata if this field is not set
+  */
+  7: optional list<string> podMetadataFields;
+
 }
 
 struct AdminConfig {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -71,10 +71,12 @@ public class SingerConfigDef {
   public static final String TOPIC_NAMES = "topic_names";
   public static final String DEFAULT_PARTITIONER = "com.pinterest.singer.writer.partitioners.DefaultPartitioner";
 
+  // KubeService configs
   public static final String SINGER_KUBE_CONFIG_PREFIX = "singer.kubernetes.";
   public static final String KUBE_POLL_FREQUENCY_SECONDS = "pollFrequencyInSeconds";
   public static final String KUBE_POD_LOG_DIR = "podLogDirectory";
   public static final String KUBE_DEFAULT_DELETION_TIMEOUT = "defaultDeletionTimeoutInSeconds";
+  public static final String POD_METADATA_FIELDS = "podMetadataFields";
 
   public static final String SINGER_ADMIN_CONFIG_PREFIX = "singer.admin.";
   public static final String ADMIN_SOCKET_FILE = "socket.file";

--- a/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerLog.java
@@ -19,6 +19,11 @@ import com.pinterest.singer.thrift.configuration.SingerLogConfig;
 
 import com.google.common.base.Preconditions;
 
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * Represent a log which can have multiple LogStreams in it.
  * All LogStreams in a SingerLog shares the same SingerLogConfig.
@@ -28,6 +33,7 @@ public class SingerLog {
   // The config for the SingerLog.
   private final SingerLogConfig singerLogConfig;
   private String podUid;
+  private Map<String, ByteBuffer> podMetadata = new HashMap<>();
 
   public SingerLog(SingerLogConfig singerLogConfig) {
     this.singerLogConfig = Preconditions.checkNotNull(singerLogConfig);
@@ -71,5 +77,21 @@ public class SingerLog {
   
   public String getPodUid() {
     return podUid;
+  }
+
+  public void addMetadata(String key, ByteBuffer value) {
+    podMetadata.put(key, value);
+  }
+
+  public Map<String, ByteBuffer> getPodMetadata() {
+    return this.podMetadata;
+  }
+
+  public void setPodMetadata(Map<String, ByteBuffer> podMetadata) {
+    this.podMetadata = podMetadata;
+  }
+
+  public Optional<ByteBuffer> getMetadata(String key) {
+    return Optional.ofNullable(podMetadata.get(key));
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -98,6 +98,8 @@ public class SingerMetrics {
   // Time elapsed between when Kubernetes deleted the pod and when Singer wrote tombstone marker
   public static final String POD_DELETION_TIME_ELAPSED = KUBE_PREFIX + "pod_deletion_time_elapsed";
   public static final String NUMBER_OF_PODS = KUBE_PREFIX + "number_of_pods";
+  public static final String POD_METADATA_UPDATED = KUBE_PREFIX + "pod_metadata_updated";
+  public static final String POD_METADATA_MAP_SIZE = KUBE_PREFIX + "pod_metadata_size";
 
   public static final String ADMIN_PREFIX = SINGER_PREIX + "admin.";
   public static final String ADMIN_SERVER_STARTED = ADMIN_PREFIX + "admin_server_started";

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
@@ -89,6 +89,8 @@ public class KubeService implements Runnable {
     Preconditions.checkNotNull(kubeConfig);
     try {
       init(kubeConfig);
+      // Register here so it is the first watcher in the set
+      addWatcher(PodMetadataTracker.getInstance());
     } catch (Exception e) {
       LOG.error("Exception while initializing KubeService", e);
       throw new RuntimeException(e);
@@ -193,7 +195,7 @@ public class KubeService implements Runnable {
         if (temp.contains("." + podName) || checkIgnoreDirectory(podName)) {
           LOG.info("Ignoring POD directory " + podName
               + " since there is a tombstone file present or has ignored directory inside");
-          // Skip adding this pod to the active podset
+          // Skip adding this pod to the active pod set
           continue;
         }
 
@@ -269,17 +271,11 @@ public class KubeService implements Runnable {
    * @throws IOException
    */
   public Set<String> fetchPodNamesFromMetadata() throws IOException {
-    LOG.debug("Attempting to make pod md request");
-    String response = SingerUtils.makeGetRequest(PODS_MD_URL);
-    LOG.debug("Received pod md response:" + response);
-    Gson gson = new Gson();
-    JsonObject obj = gson.fromJson(response, JsonObject.class);
-    LOG.debug("Finished parsing kubelet response for PODs; now extracting POD names");
+    JsonArray podList = getPodListFromKubelet();
     Set<String> podNames = new HashSet<>();
-    if (obj != null && obj.has("items")) {
-      JsonArray ary = obj.get("items").getAsJsonArray();
-      for (int i = 0; i < ary.size(); i++) {
-        JsonObject metadata = ary.get(i).getAsJsonObject().get("metadata").getAsJsonObject();
+    if (podList != null) {
+      for (int i = 0; i < podList.size(); i++) {
+        JsonObject metadata = podList.get(i).getAsJsonObject().get("metadata").getAsJsonObject();
         // pod name
         String name = metadata.get("name").getAsString();
         // to support namespace based POD directories
@@ -289,27 +285,32 @@ public class KubeService implements Runnable {
         String podUid = metadata.get("uid").getAsString();
 
         // coexist of 2 format: namespace_podname or namespace_podname_uid
-        String formatOne = namespace + "_" + name;
-        String formatTwo = namespace + "_" + name + "_" + podUid;
-        // Ignore pod if Ignore directory exists, this indicates that the pod is running its own 
-        // dedicated logging agent (dual mode)
-        if (checkIgnoreDirectory(formatOne) || checkIgnoreDirectory(formatTwo)) {
-          LOG.debug("Ignoring pod " + name + ", ignore flag found inside pod log directory");
+        String podDirectoryName = getPodDirectoryName(podLogDirectory, namespace, name, podUid);
+        // Ignore pod if Ignore directory exists, this indicates that the pod is running its own dedicated logging agent (dual mode)
+        if (checkIgnoreDirectory(podDirectoryName)) {
+          LOG.debug("Ignoring pod " + podDirectoryName + ", ignore flag found inside pod log directory");
           OpenTsdbMetricConverter.incr(SingerMetrics.PODS_IGNORED, "podname=" + name);
           continue;
         }
-        if (Files.exists(Paths.get(podLogDirectory, formatOne))) {
-          podNames.add(formatOne);
-          LOG.debug("Added format one: " + formatOne);
-        } else {
-          podNames.add(formatTwo);
-          LOG.debug("Added formate two: " + formatTwo);
-        }
+        podNames.add(podDirectoryName);
         LOG.debug("Found active POD name in JSON:" + name);
       }
     }
     LOG.debug("Pod names from kubelet:" + podNames);
     return podNames;
+  }
+
+  /**
+   * Fetch pod list from kubelet
+   *
+   * @return
+   * @throws IOException
+   */
+  public static JsonArray getPodListFromKubelet() throws IOException {
+    String response = SingerUtils.makeGetRequest(PODS_MD_URL);
+    Gson gson = new Gson();
+    JsonObject obj = gson.fromJson(response, JsonObject.class);
+    return obj != null && obj.has("items") ? obj.get("items").getAsJsonArray() : null;
   }
 
   /**
@@ -464,5 +465,14 @@ public class KubeService implements Runnable {
       return false;
     }
     return Files.exists(Paths.get(podLogDirectory, podName, ignorePodDirectory));
+  }
+
+  public static String getPodDirectoryName(String dir, String namespace, String podName, String uuid) {
+    String podFormat = namespace + "_" + podName;
+    if (Files.exists(Paths.get(dir, podFormat))) {
+      return podFormat;
+    }
+    podFormat = namespace + "_" + podName + "_" + uuid;
+    return podFormat;
   }
 }

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/KubeService.java
@@ -90,7 +90,7 @@ public class KubeService implements Runnable {
     try {
       init(kubeConfig);
       // Register here so it is the first watcher in the set
-      addWatcher(PodMetadataTracker.getInstance());
+      addWatcher(PodMetadataWatcher.getInstance());
     } catch (Exception e) {
       LOG.error("Exception while initializing KubeService", e);
       throw new RuntimeException(e);

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/PodMetadataTracker.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/PodMetadataTracker.java
@@ -1,0 +1,143 @@
+package com.pinterest.singer.kubernetes;
+
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.common.SingerSettings;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.thrift.configuration.KubeConfig;
+import com.pinterest.singer.thrift.configuration.SingerConfig;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class PodMetadataTracker implements PodWatcher {
+  private static final Logger LOG = LoggerFactory.getLogger(PodMetadataTracker.class);
+  private final Map<String, Map<String,String>> podMetadata = new ConcurrentHashMap<>();
+  private final List<String> podMetadataFields;
+  private final String podLogDirectory;
+  private static PodMetadataTracker instance;
+
+
+  public static PodMetadataTracker getInstance() {
+    if (instance == null) {
+      synchronized (PodMetadataTracker.class) {
+        if (instance == null) {
+          instance = new PodMetadataTracker();
+        }
+      }
+    }
+    return instance;
+  }
+
+  protected PodMetadataTracker() {
+    SingerConfig config = SingerSettings.getSingerConfig();
+    Preconditions.checkNotNull(config);
+    KubeConfig kubeConfig = config.getKubeConfig();
+    Preconditions.checkNotNull(kubeConfig);
+    podLogDirectory = kubeConfig.getPodLogDirectory();
+    if (kubeConfig.getPodMetadataFields() == null || kubeConfig.getPodMetadataFields().isEmpty()) {
+      LOG.warn("Pod metadata fields are not set in the config. Pod metadata will not be updated.");
+    }
+    podMetadataFields = kubeConfig.getPodMetadataFields();
+  }
+
+  @VisibleForTesting
+  protected PodMetadataTracker(KubeConfig kubeConfig) {
+    Preconditions.checkNotNull(kubeConfig);
+    podMetadataFields = kubeConfig.getPodMetadataFields();
+    podLogDirectory = kubeConfig.getPodLogDirectory();
+  }
+
+  @VisibleForTesting
+  public Map<String, Map<String,String>> getPodMetadataMap() {
+    return new HashMap<>(podMetadata);
+  }
+
+  @Override
+  public void podCreated(String podUid) {
+    try {
+      if (!podMetadata.containsKey(podUid)) {
+        updatePodMetadata(podUid);
+        OpenTsdbMetricConverter.gauge(SingerMetrics.POD_METADATA_MAP_SIZE, podMetadata.size());
+      }
+    } catch (IOException e) {
+      LOG.error("Failed to update pod metadata for pod: {}", podUid, e);
+    }
+  }
+
+  @Override
+  public void podDeleted(String podUid) {
+    podMetadata.remove(podUid);
+    OpenTsdbMetricConverter.gauge(SingerMetrics.POD_METADATA_MAP_SIZE, podMetadata.size());
+  }
+
+  /**
+   * Update podMetadata from kubelet for active pods. This method is only called after
+   * the initial file system pod discovery.
+   *
+   * @throws IOException
+   */
+  private void updatePodMetadata(String podUid) throws IOException {
+    if (podMetadataFields == null || podMetadataFields.isEmpty()) {
+      return;
+    }
+    JsonArray podList = KubeService.getPodListFromKubelet();
+    if (podList != null) {
+      for (int i = 0; i < podList.size(); i++) {
+        JsonObject metadata = podList.get(i).getAsJsonObject().get("metadata").getAsJsonObject();
+        String
+            podDirectoryName =
+            KubeService.getPodDirectoryName(podLogDirectory, metadata.get("namespace").getAsString(),
+                metadata.get("name").getAsString(), metadata.get("uid").getAsString());
+        if (podDirectoryName.equals(podUid)) {
+          podMetadata.put(podUid, extractPodMetadataFields(metadata, podMetadataFields));
+          LOG.info("Pod metadata updated for pod: {}", podUid);
+          OpenTsdbMetricConverter.incr(SingerMetrics.POD_METADATA_UPDATED,
+              "podName=" + podUid, "namespace=" + metadata.get("namespace").getAsString());
+        }
+      }
+    }
+  }
+
+  /**
+   * Extract select fields from pod metadata items. Each nested field should be separated by a colon, e.g:
+   * "labels:app" will extract the "app" field from the "labels" object.
+   *
+   * @param metadata pod metadata
+   * @param podMetadataFields list of fields to extract
+   * @return a JsonObject containing the extracted fields
+   */
+  public Map<String, String> extractPodMetadataFields(JsonObject metadata, List<String> podMetadataFields) {
+    Map<String, String> extractedFields = new HashMap<>();
+    for (String fieldPath : podMetadataFields) {
+      JsonElement currentElement = metadata;
+      String fieldKey = null;
+      for (String key : fieldPath.split(":")) {
+        if (currentElement == null || !currentElement.isJsonObject()) {
+          currentElement = null;
+          break;
+        }
+        currentElement = currentElement.getAsJsonObject().get(key);
+        fieldKey = key;
+      }
+      if (fieldKey != null && currentElement != null && currentElement.isJsonPrimitive()) {
+        extractedFields.putIfAbsent(fieldKey, currentElement.toString());
+      }
+    }
+    return extractedFields;
+  }
+
+  public Map<String, String> getPodMetadata(String podName) {
+    return podMetadata.get(podName) != null ? podMetadata.get(podName) : null;
+  }
+}

--- a/singer/src/main/java/com/pinterest/singer/kubernetes/PodMetadataWatcher.java
+++ b/singer/src/main/java/com/pinterest/singer/kubernetes/PodMetadataWatcher.java
@@ -20,26 +20,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class PodMetadataTracker implements PodWatcher {
-  private static final Logger LOG = LoggerFactory.getLogger(PodMetadataTracker.class);
+public class PodMetadataWatcher implements PodWatcher {
+  private static final Logger LOG = LoggerFactory.getLogger(PodMetadataWatcher.class);
   private final Map<String, Map<String,String>> podMetadata = new ConcurrentHashMap<>();
   private final List<String> podMetadataFields;
   private final String podLogDirectory;
-  private static PodMetadataTracker instance;
+  private static PodMetadataWatcher instance;
 
 
-  public static PodMetadataTracker getInstance() {
+  public static PodMetadataWatcher getInstance() {
     if (instance == null) {
-      synchronized (PodMetadataTracker.class) {
+      synchronized (PodMetadataWatcher.class) {
         if (instance == null) {
-          instance = new PodMetadataTracker();
+          instance = new PodMetadataWatcher();
         }
       }
     }
     return instance;
   }
 
-  protected PodMetadataTracker() {
+  protected PodMetadataWatcher() {
     SingerConfig config = SingerSettings.getSingerConfig();
     Preconditions.checkNotNull(config);
     KubeConfig kubeConfig = config.getKubeConfig();
@@ -52,7 +52,7 @@ public class PodMetadataTracker implements PodWatcher {
   }
 
   @VisibleForTesting
-  protected PodMetadataTracker(KubeConfig kubeConfig) {
+  protected PodMetadataWatcher(KubeConfig kubeConfig) {
     Preconditions.checkNotNull(kubeConfig);
     podMetadataFields = kubeConfig.getPodMetadataFields();
     podLogDirectory = kubeConfig.getPodLogDirectory();

--- a/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
@@ -58,7 +58,7 @@ import com.pinterest.singer.common.SingerMetrics;
 import com.pinterest.singer.common.errors.LogStreamException;
 import com.pinterest.singer.common.errors.SingerLogException;
 import com.pinterest.singer.kubernetes.KubeService;
-import com.pinterest.singer.kubernetes.PodMetadataTracker;
+import com.pinterest.singer.kubernetes.PodMetadataWatcher;
 import com.pinterest.singer.kubernetes.PodWatcher;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogFile;
@@ -719,7 +719,7 @@ public class LogStreamManager implements PodWatcher {
           clone.setName(podUid + POD_LOGNAME_SEPARATOR + clone.getName());
           singerLog = new SingerLog(clone, podUid);
           // Add pod metadata to the singer log
-          Map<String, String> podMetadata = PodMetadataTracker.getInstance().getPodMetadata(podUid);
+          Map<String, String> podMetadata = PodMetadataWatcher.getInstance().getPodMetadata(podUid);
           if (podMetadata != null) {
             LOG.info("Initializing pod metadata {} for pod: {}", podMetadata, podUid);
             OpenTsdbMetricConverter.incr("pod_metadata_enabled", 1, "pod=" + podUid, "log=" + clone.getName());

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -100,6 +100,10 @@ public class TextLogFileReader implements LogFileReader {
       headers.put("hostname", SingerUtils.getByteBuf(hostname));
       headers.put("file", SingerUtils.getByteBuf(path));
       headers.put("availabilityZone", SingerUtils.getByteBuf(availabilityZone));
+      Map<String, ByteBuffer> logMetadata = logStream.getSingerLog().getPodMetadata();
+      if (logMetadata != null && !logMetadata.isEmpty()) {
+        headers.putAll(logMetadata);
+      }
     }
 
     this.hostname = hostname;

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
@@ -110,6 +110,10 @@ public class ThriftLogFileReader implements LogFileReader {
       headers.put("hostname", SingerUtils.getByteBuf(hostname));
       headers.put("file", SingerUtils.getByteBuf(path));
       headers.put("availabilityZone", SingerUtils.getByteBuf(availabilityZone));
+      Map<String, ByteBuffer> logMetadata = logStream.getSingerLog().getPodMetadata();
+      if (logMetadata != null && !logMetadata.isEmpty()) {
+        headers.putAll(logMetadata);
+      }
     }
 
     this.thriftReader = new ThriftReader(

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -276,6 +276,12 @@ public class LogConfigUtils {
           subsetConfig.getInt(SingerConfigDef.KUBE_POLL_FREQUENCY_SECONDS));
     }
 
+    if (subsetConfig.containsKey(SingerConfigDef.POD_METADATA_FIELDS)) {
+      config.setPodMetadataFields(subsetConfig.getList(SingerConfigDef.POD_METADATA_FIELDS).stream()
+          .map(Object::toString)
+          .collect(Collectors.toList()));
+    }
+
     if (subsetConfig.containsKey(SingerConfigDef.KUBE_POD_LOG_DIR)) {
       String logDirectory = subsetConfig.getString(SingerConfigDef.KUBE_POD_LOG_DIR);
       // normalize path before setting the property

--- a/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
+++ b/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
@@ -56,12 +56,12 @@ public class TestKubeService {
 
     private static HttpServer server;
     private final List<String> podNames = Arrays.asList(
-        "default_enimanager-ppl56_b1a2a0c2-d3ab-11e7-a1db-0674200569b6",
-        "default_zk-update-monitor-r1vlt_7d1d8b00-b532-11e7-b628-0674200569b6",
-        "default_tcollector-q4qx8_8ad2dba8-b84c-11e7-b628-0674200569b6",
-        "default_metrics-agent-8vm9g_bfc5f760-b8e1-11e7-b628-0674200569b6",
-        "kube-system_kubernetes-dashboard-1835568627-hhfhj_a343643b-b936-11e7-b628-0674200569b6",
-        "kubernetes-plugin_test-ci-0_f084af12-cbe6-11e7-a1db-0674200569b6");
+        "default_nginx-deployment-5c689d7589-abcde_12345678-1234-1234-1234-1234567890ab",
+        "default_nginx-deployment-5c689d7589-fghij_12345678-1234-5678-1234-567890abcdef",
+        "default_backend-service-7987d5b5c-12345_54321678-9876-5432-9876-5432198765ac",
+        "default_frontend-service-7f8d5b7c6-xzywv_54321098-7654-3210-6798-5432123456dc",
+        "default_database-7f8d5b7c6-mnopq_98765432-7654-4321-6543-987654321098",
+        "default_analytics-57c66b48c6-qwer7_09876543-7654-5432-8765-098765432109");
 
     @BeforeClass
     public static void beforeClass() throws IOException {
@@ -129,8 +129,8 @@ public class TestKubeService {
     public void testPodFetchWithTwoFormats() throws IOException {
         registerGoodResponse();
 
-        String firstFormat = "default_enimanager-ppl56";
-        String secondFormat = "default_enimanager-ppl56_b1a2a0c2-d3ab-11e7-a1db-0674200569b6";
+        String firstFormat = "default_nginx-deployment-5c689d7589-abcde";
+        String secondFormat = "default_nginx-deployment-5c689d7589-abcde_12345678-1234-1234-1234-1234567890ab";
         String podDirectory = "target/kube";
         File f = new File(podDirectory + "/" + firstFormat);
         if (!f.exists()) {
@@ -189,7 +189,7 @@ public class TestKubeService {
 
         KubeConfig kubeConfig = new KubeConfig();
         kubeConfig.setPodMetadataFields(
-            Arrays.asList("labels:name", "namespace", "annotations:kubernetes.io/config.source"));
+            Arrays.asList("name", "namespace", "uid"));
         KubeService kubeService = new KubeService(kubeConfig);
         PodMetadataWatcher pmdTracker = new PodMetadataWatcher(kubeConfig);
         kubeService.addWatcher(pmdTracker);
@@ -200,7 +200,8 @@ public class TestKubeService {
         for (Map.Entry<String, Map<String, String>> pod : pmdTracker.getPodMetadataMap().entrySet()) {
             assertTrue(podNames.contains(pod.getKey()));
             assertNotNull(pod.getValue().get("namespace"));
-            assertNotNull(pod.getValue().get("kubernetes.io/config.source"));
+            assertNotNull(pod.getValue().get("name"));
+            assertNotNull(pod.getValue().get("uid"));
         }
         kubeService.updatePodWatchers(podNames.get(podNames.size() - 1), true);
         assertEquals(podNames.size() - 1, pmdTracker.getPodMetadataMap().size());

--- a/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
+++ b/singer/src/test/java/com/pinterest/singer/kubernetes/TestKubeService.java
@@ -30,7 +30,6 @@ import java.nio.file.Files;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -192,7 +191,7 @@ public class TestKubeService {
         kubeConfig.setPodMetadataFields(
             Arrays.asList("labels:name", "namespace", "annotations:kubernetes.io/config.source"));
         KubeService kubeService = new KubeService(kubeConfig);
-        PodMetadataTracker pmdTracker = new PodMetadataTracker(kubeConfig);
+        PodMetadataWatcher pmdTracker = new PodMetadataWatcher(kubeConfig);
         kubeService.addWatcher(pmdTracker);
         for (String pod : podNames) {
             kubeService.updatePodWatchers(pod, false);

--- a/singer/src/test/resources/pods-badresponse.json
+++ b/singer/src/test/resources/pods-badresponse.json
@@ -1,1200 +1,266 @@
 {
   "kind": "PodList",
   "apiVersion": "v1",
-  "metadata": {}
   "items": [
     {
       "metadata": {
-        "name": "enimanager-ppl56",
-        "generateName": "enimanager-",
+        "name": "nginx-deployment-5c689d7589-abcde",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/enimanager-ppl56",
-        "uid": "b1a2a0c2-d3ab-11e7-a1db-0674200569b6",
-        "resourceVersion": "33091093",
-        "creationTimestamp": "2017-11-27T19:46:43Z",
-        "labels": {
-          "controller-revision-hash": "1181101742",
-          "name": "enimanager",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:46:43.127689764Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"enimanager\",\"uid\":\"b1a1beec-d3ab-11e7-a1db-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"33091082\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "enimanager",
-            "uid": "b1a1beec-d3ab-11e7-a1db-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "kubelet",
-            "hostPath": {
-              "path": "/var/lib/kubelet"
-            }
-          },
-          {
-            "name": "enimanager",
-            "hostPath": {
-              "path": "/mnt/enimanager"
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "enimanager",
-            "image": "1234567890.cloud-url/enimanager:2342384234234njadsh23j42h3424234gh23g4j2g34",
-            "env": [
-              {
-                "name": "RODIMUS_TOKEN",
-                "value": "jnfDmk5cr9Z6hpWpR1rhxeKGhJzd78"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "enimanager",
-                "mountPath": "/mnt/enimanager"
-              },
-              {
-                "name": "kubelet",
-                "mountPath": "/var/lib/kubelet"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
-      },
+        "uid": "12345678-1234-1234-1234-1234567890ab"
       "status": {
         "phase": "Running",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:46:43Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:47:01Z"
+            "status": "True"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:47:01Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-11-27T19:46:43Z",
+        "hostIP": "192.168.0.1",
+        "podIP": "10.0.0.1",
+        "startTime": "2023-10-01T12:00:00Z",
         "containerStatuses": [
           {
-            "name": "enimanager",
+            "name": "nginx",
             "state": {
               "running": {
-                "startedAt": "2017-11-27T19:47:00Z"
+                "startedAt": "2023-10-01T12:01:00Z"
               }
             },
-            "lastState": {},
             "ready": true,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/enimanager:2342384234234njadsh23j42h3424234gh23g4j2g34",
-            "imageID": "docker-pullable://1234567890.cloud-url/enimanager@sha256:472bb17b34ad49d16a05f5cd8f7c9b046578edbebb63925ac7bf72dfca20104b",
-            "containerID": "docker://d035782b2429893dc45618e0375a2409c22a8cd239ff9c0c446cb429b5a35b5c"
+            "image": "nginx:latest",
+            "imageID": "docker://sha256:abc123def456..."
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "zk-update-monitor-r1vlt",
-        "generateName": "zk-update-monitor-",
+        "name": "nginx-deployment-5c689d7589-fghij",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/zk-update-monitor-r1vlt",
-        "uid": "7d1d8b00-b532-11e7-b628-0674200569b6",
-        "resourceVersion": "32518932",
-        "creationTimestamp": "2017-10-20T01:03:31Z",
-        "labels": {
-          "controller-revision-hash": "4079167259",
-          "name": "zk-update-monitor",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858402679Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"zk-update-monitor\",\"uid\":\"fe580c9c-b092-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"12847168\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "zk-update-monitor",
-            "uid": "fe580c9c-b092-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "cellzkhosts",
-            "hostPath": {
-              "path": "/etc/cell_zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "zkhosts",
-            "hostPath": {
-              "path": "/etc/zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log/zk_update_monitor"
-            }
-          },
-          {
-            "name": "downloadmeta",
-            "hostPath": {
-              "path": "/var/zum_download_meta"
-            }
-          },
-          {
-            "name": "zumconfig",
-            "hostPath": {
-              "path": "/etc/zk_update_monitor.d"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "zk-update-monitor",
-            "image": "1234567890.cloud-url/zk-update-monitor:e11b8230120d18315e87092e45a3ecfd101c2977",
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "cellzkhosts",
-                "mountPath": "/etc/cell_zookeeper_hosts.conf"
-              },
-              {
-                "name": "zkhosts",
-                "mountPath": "/etc/zookeeper_hosts.conf"
-              },
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log/zk_update_monitor"
-              },
-              {
-                "name": "downloadmeta",
-                "mountPath": "/var/zum_download_meta"
-              },
-              {
-                "name": "zumconfig",
-                "mountPath": "/etc/zk_update_monitor.d"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
+        "uid": "12345678-1234-5678-1234-567890abcdef"
       },
       "status": {
         "phase": "Running",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-20T01:03:35Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2018-02-07T08:45:17Z"
+            "status": "True"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-20T01:03:49Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-20T01:03:35Z",
+        "hostIP": "192.168.0.2",
+        "podIP": "10.0.0.2",
+        "startTime": "2023-10-01T12:05:00Z",
         "containerStatuses": [
           {
-            "name": "zk-update-monitor",
+            "name": "nginx",
             "state": {
               "running": {
-                "startedAt": "2018-02-07T08:45:16Z"
+                "startedAt": "2023-10-01T12:06:00Z"
               }
             },
-            "lastState": {
-              "terminated": {
-                "exitCode": 137,
-                "reason": "Error",
-                "startedAt": "2018-02-06T07:57:00Z",
-                "finishedAt": "2018-02-07T08:45:15Z",
-                "containerID": "docker://f1713cb43857ba2bea8194362085bf2b4ad5e603d80ce37a0810e28b04e07337"
-              }
-            },
-            "ready": true,
-            "restartCount": 103,
-            "image": "1234567890.cloud-url/zk-update-monitor:e11b8230120d18315e87092e45a3ecfd101c2977",
-            "imageID": "docker-pullable://1234567890.cloud-url/zk-update-monitor@sha256:39411011296a7c0dbd1b22e56adca073a1801d3c036dfa1fb10e7aa475420406",
-            "containerID": "docker://a4be6120aefe99721ba48525be5d4076e06933aa8b5b2d2da8351675aac13a59"
-          }
-        ],
-        "qosClass": "BestEffort"
-      }
-    },
-    {
-      "metadata": {
-        "name": "tcollector-q4qx8",
-        "generateName": "tcollector-",
-        "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/tcollector-q4qx8",
-        "uid": "8ad2dba8-b84c-11e7-b628-0674200569b6",
-        "resourceVersion": "17165145",
-        "creationTimestamp": "2017-10-23T23:47:34Z",
-        "labels": {
-          "controller-revision-hash": "45790700",
-          "name": "tcollector",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858411903Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"tcollector\",\"uid\":\"8ad12af5-b84c-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17164414\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "tcollector",
-            "uid": "8ad12af5-b84c-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "cellzkhosts",
-            "hostPath": {
-              "path": "/etc/cell_zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "zkhosts",
-            "hostPath": {
-              "path": "/etc/zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "run",
-            "hostPath": {
-              "path": "/run"
-            }
-          },
-          {
-            "name": "cgroup",
-            "hostPath": {
-              "path": "/sys/fs/cgroup"
-            }
-          },
-          {
-            "name": "deployd",
-            "hostPath": {
-              "path": "/mnt/deployd"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "tcollector",
-            "image": "1234567890.cloud-url/tcollector:763db0abff6ead4afe4aed15124f6fe4ca7dc295",
-            "env": [
-              {
-                "name": "LOGFILE",
-                "value": "/var/log/tcollector.log"
-              },
-              {
-                "name": "PIDFILE",
-                "value": "/var/run/tcollector.log"
-              },
-              {
-                "name": "HOST",
-                "value": "$HOSTNAME"
-              },
-              {
-                "name": "CLUSTER",
-                "value": "k8sworker"
-              },
-              {
-                "name": "EC2_ZONE",
-                "value": "us-east-1e"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "cellzkhosts",
-                "mountPath": "/etc/cell_zookeeper_hosts.conf"
-              },
-              {
-                "name": "zkhosts",
-                "mountPath": "/etc/zookeeper_hosts.conf"
-              },
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "run",
-                "mountPath": "/run"
-              },
-              {
-                "name": "cgroup",
-                "mountPath": "/sys/fs/cgroup"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "deployd",
-                "mountPath": "/mnt/deployd"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
-      },
-      "status": {
-        "phase": "Running",
-        "conditions": [
-          {
-            "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:34Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:35Z"
-          },
-          {
-            "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:35Z"
-          }
-        ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-23T23:47:34Z",
-        "containerStatuses": [
-          {
-            "name": "tcollector",
-            "state": {
-              "running": {
-                "startedAt": "2017-10-23T23:47:35Z"
-              }
-            },
-            "lastState": {},
             "ready": true,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/tcollector:763db0abff6ead4afe4aed15124f6fe4ca7dc295",
-            "imageID": "docker-pullable://1234567890.cloud-url/tcollector@sha256:a180b767f8fc13b7eadf7890d969dcefc154c90ba7565c4269f80926d3e92338",
-            "containerID": "docker://56336c15058d46041e8977a932039c68f9fe5ea7a1f14415a5f7d316da3c9911"
+            "image": "nginx:latest",
+            "imageID": "docker://sha256:abc123def456..."
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "metrics-agent-8vm9g",
-        "generateName": "metrics-agent-",
+        "name": "backend-service-7987d5b5c-12345",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/metrics-agent-8vm9g",
-        "uid": "bfc5f760-b8e1-11e7-b628-0674200569b6",
-        "resourceVersion": "17608680",
-        "creationTimestamp": "2017-10-24T17:35:38Z",
-        "labels": {
-          "controller-revision-hash": "4410873",
-          "name": "metrics-agent",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.85838677Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"metrics-agent\",\"uid\":\"bfc3d9c0-b8e1-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17608014\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "metrics-agent",
-            "uid": "bfc3d9c0-b8e1-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "metrics-agent",
-            "image": "1234567890.cloud-url/metrics-agent:87155c18715c3e12301e42ec6cb6f9f5bb3c1e36",
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
+        "uid": "54321678-9876-5432-9876-5432198765ac"
       },
       "status": {
-        "phase": "Running",
+        "phase": "Pending",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:38Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:47Z"
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:47Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-24T17:35:38Z",
+        "hostIP": "192.168.0.3",
+        "startTime": "2023-10-01T13:00:00Z",
         "containerStatuses": [
           {
-            "name": "metrics-agent",
+            "name": "backend",
             "state": {
-              "running": {
-                "startedAt": "2017-10-24T17:35:46Z"
+              "waiting": {
+                "reason": "ContainerCreating"
               }
             },
-            "lastState": {},
-            "ready": true,
+            "ready": false,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/metrics-agent:87155c18715c3e12301e42ec6cb6f9f5bb3c1e36",
-            "imageID": "docker-pullable://1234567890.cloud-url/metrics-agent@sha256:b330453145957f8cdee90ac47ea8e214175a6aba1bca95bc142ae35fa50d964e",
-            "containerID": "docker://6a920a80a3b9892e957ec45dfd86936bded1b43a0ca16863e42afadc17951731"
+            "image": "backend:latest"
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "kubernetes-dashboard-1835568627-hhfhj",
-        "generateName": "kubernetes-dashboard-1835568627-",
-        "namespace": "kube-system",
-        "selfLink": "/api/v1/namespaces/kube-system/pods/kubernetes-dashboard-1835568627-hhfhj",
-        "uid": "a343643b-b936-11e7-b628-0674200569b6",
-        "resourceVersion": "17831826",
-        "creationTimestamp": "2017-10-25T03:43:17Z",
-        "labels": {
-          "k8s-app": "kubernetes-dashboard",
-          "pod-template-hash": "1835568627"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.85842129Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"kube-system\",\"name\":\"kubernetes-dashboard-1835568627\",\"uid\":\"a3427a70-b936-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17831783\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "ReplicaSet",
-            "name": "kubernetes-dashboard-1835568627",
-            "uid": "a3427a70-b936-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "tempvol",
-            "emptyDir": {
-              "sizeLimit": "0"
-            }
-          },
-          {
-            "name": "kubernetes-dashboard-token-mz6xk",
-            "secret": {
-              "secretName": "kubernetes-dashboard-token-mz6xk",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "kubernetes-dashboard",
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1",
-            "args": [
-              "--apiserver-host=http://10.1.100.201:8080"
-            ],
-            "ports": [
-              {
-                "hostPort": 9090,
-                "containerPort": 9090,
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "tempvol",
-                "mountPath": "/tmp"
-              },
-              {
-                "name": "kubernetes-dashboard-token-mz6xk",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "livenessProbe": {
-              "httpGet": {
-                "path": "/",
-                "port": 9090,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 30,
-              "timeoutSeconds": 30,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "kubernetes-dashboard",
-        "serviceAccount": "kubernetes-dashboard",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node-role.kubernetes.io/master",
-            "effect": "NoSchedule"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute",
-            "tolerationSeconds": 300
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute",
-            "tolerationSeconds": 300
-          }
-        ]
+        "name": "frontend-service-7f8d5b7c6-xzywv",
+        "namespace": "default",
+        "uid": "54321098-7654-3210-6798-5432123456dc"
       },
       "status": {
-        "phase": "Running",
+        "phase": "Succeeded",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:17Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:21Z"
+            "status": "False"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:17Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-25T03:43:17Z",
+        "hostIP": "192.168.0.4",
+        "startTime": "2023-10-01T14:00:00Z",
         "containerStatuses": [
           {
-            "name": "kubernetes-dashboard",
-            "state": {
-              "running": {
-                "startedAt": "2017-10-25T03:43:21Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1",
-            "imageID": "docker-pullable://gcr.io/google_containers/kubernetes-dashboard-amd64@sha256:327cfef378e88ffbc327f98dd24adacf6c9363c042db78e922d050f2bdcf6f78",
-            "containerID": "docker://82d3c78b28bdd202c401005b130d6550673f5d541cc4d1396e521f348e6bc94d"
-          }
-        ],
-        "qosClass": "BestEffort"
-      }
-    },
-    {
-      "metadata": {
-        "name": "test-ci-0",
-        "generateName": "test-ci-",
-        "namespace": "kubernetes-plugin",
-        "selfLink": "/api/v1/namespaces/kubernetes-plugin/pods/test-ci-0",
-        "uid": "f084af12-cbe6-11e7-a1db-0674200569b6",
-        "resourceVersion": "33082906",
-        "creationTimestamp": "2017-11-17T22:30:39Z",
-        "labels": {
-          "controller-revision-hash": "test-ci-2949316050",
-          "name": "test-ci"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858430027Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"StatefulSet\",\"namespace\":\"kubernetes-plugin\",\"name\":\"test-ci\",\"uid\":\"c41c7d07-cbe5-11e7-a1db-0674200569b6\",\"apiVersion\":\"apps/v1beta1\",\"resourceVersion\":\"26293887\"}}\n",
-          "pod.alpha.kubernetes.io/init-container-statuses": "[{\"name\":\"init-jenkins-home\",\"state\":{\"terminated\":{\"exitCode\":0,\"reason\":\"Completed\",\"startedAt\":\"2017-11-17T22:30:40Z\",\"finishedAt\":\"2017-11-17T22:30:40Z\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}},\"lastState\":{},\"ready\":true,\"restartCount\":0,\"image\":\"busybox:latest\",\"imageID\":\"docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}]",
-          "pod.alpha.kubernetes.io/init-containers": "[{\"name\":\"init-jenkins-home\",\"image\":\"busybox\",\"command\":[\"sh\",\"-c\",\"chmod 777 /var/jenkins_home\"],\"resources\":{},\"volumeMounts\":[{\"name\":\"jenkins-home\",\"mountPath\":\"/var/jenkins_home\"}],\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"Always\"}]",
-          "pod.beta.kubernetes.io/init-container-statuses": "[{\"name\":\"init-jenkins-home\",\"state\":{\"terminated\":{\"exitCode\":0,\"reason\":\"Completed\",\"startedAt\":\"2017-11-17T22:30:40Z\",\"finishedAt\":\"2017-11-17T22:30:40Z\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}},\"lastState\":{},\"ready\":true,\"restartCount\":0,\"image\":\"busybox:latest\",\"imageID\":\"docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}]",
-          "pod.beta.kubernetes.io/init-containers": "[{\"name\":\"init-jenkins-home\",\"image\":\"busybox\",\"command\":[\"sh\",\"-c\",\"chmod 777 /var/jenkins_home\"],\"resources\":{},\"volumeMounts\":[{\"name\":\"jenkins-home\",\"mountPath\":\"/var/jenkins_home\"}],\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"Always\"}]"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1beta1",
-            "kind": "StatefulSet",
-            "name": "test-ci",
-            "uid": "c41c7d07-cbe5-11e7-a1db-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "jenkins-home",
-            "hostPath": {
-              "path": "/jenkins/jenkinsmaster"
-            }
-          },
-          {
-            "name": "knox-bin",
-            "hostPath": {
-              "path": "/usr/bin/knox"
-            }
-          },
-          {
-            "name": "knox-lib",
-            "hostPath": {
-              "path": "/var/lib/knox"
-            }
-          },
-          {
-            "name": "normandie",
-            "hostPath": {
-              "path": "/var/lib/normandie"
-            }
-          }
-        ],
-        "initContainers": [
-          {
-            "name": "init-jenkins-home",
-            "image": "busybox",
-            "command": [
-              "sh",
-              "-c",
-              "chmod 777 /var/jenkins_home"
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "jenkins-home",
-                "mountPath": "/var/jenkins_home"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          }
-        ],
-        "containers": [
-          {
-            "name": "oauth-proxy",
-            "image": "1234567890.cloud-url/nginx-oauth-proxy:latest",
-            "ports": [
-              {
-                "hostPort": 80,
-                "containerPort": 80,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "SERVICE",
-                "value": "jenkins"
-              },
-              {
-                "name": "PROXY_PORT",
-                "value": "8080"
-              },
-              {
-                "name": "CALLBACK_HOST",
-                "value": "test-ci.pinadmin.com"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "knox-bin",
-                "mountPath": "/usr/bin/knox"
-              },
-              {
-                "name": "knox-lib",
-                "mountPath": "/var/lib/knox"
-              },
-              {
-                "name": "normandie",
-                "mountPath": "/var/lib/normandie"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          },
-          {
-            "name": "test-ci",
-            "image": "1234567890.cloud-url/jenkins:jenkins-master",
-            "ports": [
-              {
-                "hostPort": 8080,
-                "containerPort": 8080,
-                "protocol": "TCP"
-              },
-              {
-                "hostPort": 50000,
-                "containerPort": 50000,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "JAVA_OPTS",
-                "value": "-Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Los_Angeles -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85 -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000"
-              }
-            ],
-            "resources": {
-              "limits": {
-                "cpu": "30"
-              },
-              "requests": {
-                "cpu": "30"
-              }
-            },
-            "volumeMounts": [
-              {
-                "name": "jenkins-home",
-                "mountPath": "/var/jenkins_home"
-              }
-            ],
-            "livenessProbe": {
-              "httpGet": {
-                "path": "/login",
-                "port": 8080,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "timeoutSeconds": 5,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "readinessProbe": {
-              "httpGet": {
-                "path": "/login",
-                "port": 8080,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 5,
-              "timeoutSeconds": 5,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 1,
-        "dnsPolicy": "ClusterFirst",
-        "nodeSelector": {
-          "jenkins/node": "test-ci"
-        },
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "hostname": "test-ci-0",
-        "subdomain": "test-ci",
-        "schedulerName": "default-scheduler"
-      },
-      "status": {
-        "phase": "Running",
-        "conditions": [
-          {
-            "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-17T22:30:41Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:44:54Z"
-          },
-          {
-            "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-17T22:30:39Z"
-          }
-        ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-11-17T22:30:39Z",
-        "initContainerStatuses": [
-          {
-            "name": "init-jenkins-home",
+            "name": "frontend",
             "state": {
               "terminated": {
                 "exitCode": 0,
                 "reason": "Completed",
-                "startedAt": "2017-11-17T22:30:40Z",
-                "finishedAt": "2017-11-17T22:30:40Z",
-                "containerID": "docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848"
+                "finishedAt": "2023-10-01T14:30:00Z"
               }
             },
-            "lastState": {},
-            "ready": true,
+            "ready": false,
             "restartCount": 0,
-            "image": "busybox:latest",
-            "imageID": "docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0",
-            "containerID": "docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848"
+            "image": "frontend:latest",
+            "imageID": "docker://sha256:abcdef123456..."
           }
-        ],
-        "containerStatuses": [
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "database-7f8d5b7c6-mnopq",
+        "namespace": "default",
+        "uid": "98765432-7654-4321-6543-987654321098"
+      },
+      "status": {
+        "phase": "Failed",
+        "conditions": [
           {
-            "name": "oauth-proxy",
-            "state": {
-              "running": {
-                "startedAt": "2017-11-18T10:17:24Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "1234567890.cloud-url/nginx-oauth-proxy:latest",
-            "imageID": "docker-pullable://1234567890.cloud-url/nginx-oauth-proxy@sha256:16c4e8a21455f206cb4051de25a9e58a654743f4c57ed78d99a679a112f316c9",
-            "containerID": "docker://173b2e01223e4c0f3754f84da4c9685645cf0392bf44f1687bf871860c222276"
+            "type": "Initialized",
+            "status": "True"
           },
           {
-            "name": "test-ci",
-            "state": {
-              "running": {
-                "startedAt": "2017-11-27T18:58:05Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "1234567890.cloud-url/jenkins:jenkins-master",
-            "imageID": "docker-pullable://1234567890.cloud-url/jenkins@sha256:9fdb938c6a1e343429eabcf44626ff326fbaa8fa7e672257eaa3fd9018471021",
-            "containerID": "docker://5cadd5f06d30664513aa97639a2433775c1364b516f05c2203bec9be4b8a8956"
+            "type": "Ready",
+            "status": "False"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True"
           }
         ],
-        "qosClass": "Burstable"
+        "hostIP": "192.168.0.5",
+        "startTime": "2023-10-01T15:00:00Z",
+        "containerStatuses": [
+          {
+            "name": "database",
+            "state": {
+              "terminated": {
+                "exitCode": 1,
+                "reason": "Error",
+                "message": "CrashLoopBackOff",
+                "finishedAt": "2023-10-01T15:30:00Z"
+              }
+            },
+            "ready": false,
+            "restartCount": 3,
+            "image": "database:latest",
+            "imageID": "docker://sha256:123456abcdef..."
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "analytics-57c66b48c6-qwer7",
+        "namespace": "default",
+        "uid": "09876543-7654-5432-8765-098765432109"
+      },
+      "status": {
+        "phase": "Unknown",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "Unknown"
+          },
+          {
+            "type": "Ready",
+            "status": "Unknown"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "Unknown"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "Unknown"
+          }
+        ],
+        "hostIP": "192.168.0.6",
+        "startTime": "2023-10-01T16:00:00Z",
+        "containerStatuses": [
+          {
+            "name": "analytics",
+            "state": {
+              "waiting": {
+                "reason": "Unknown"
+              }
+            },
+            "ready": false,
+            "restartCount": 0,
+            "image": "analytics:beta",
+            "imageID": ""
+          }
+        ]
       }
     }
   ]

--- a/singer/src/test/resources/pods-goodresponse.json
+++ b/singer/src/test/resources/pods-goodresponse.json
@@ -1,1200 +1,267 @@
 {
   "kind": "PodList",
   "apiVersion": "v1",
-  "metadata": {},
   "items": [
     {
       "metadata": {
-        "name": "enimanager-ppl56",
-        "generateName": "enimanager-",
+        "name": "nginx-deployment-5c689d7589-abcde",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/enimanager-ppl56",
-        "uid": "b1a2a0c2-d3ab-11e7-a1db-0674200569b6",
-        "resourceVersion": "33091093",
-        "creationTimestamp": "2017-11-27T19:46:43Z",
-        "labels": {
-          "controller-revision-hash": "1181101742",
-          "name": "enimanager",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:46:43.127689764Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"enimanager\",\"uid\":\"b1a1beec-d3ab-11e7-a1db-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"33091082\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "enimanager",
-            "uid": "b1a1beec-d3ab-11e7-a1db-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "kubelet",
-            "hostPath": {
-              "path": "/var/lib/kubelet"
-            }
-          },
-          {
-            "name": "enimanager",
-            "hostPath": {
-              "path": "/mnt/enimanager"
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "enimanager",
-            "image": "1234567890.cloud-url/enimanager:2342384234234njadsh23j42h3424234gh23g4j2g34",
-            "env": [
-              {
-                "name": "RODIMUS_TOKEN",
-                "value": "jnfDmk5cr9Z6hpWpR1rhxeKGhJzd78"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "enimanager",
-                "mountPath": "/mnt/enimanager"
-              },
-              {
-                "name": "kubelet",
-                "mountPath": "/var/lib/kubelet"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
+        "uid": "12345678-1234-1234-1234-1234567890ab"
       },
       "status": {
         "phase": "Running",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:46:43Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:47:01Z"
+            "status": "True"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:47:01Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-11-27T19:46:43Z",
+        "hostIP": "192.168.0.1",
+        "podIP": "10.0.0.1",
+        "startTime": "2023-10-01T12:00:00Z",
         "containerStatuses": [
           {
-            "name": "enimanager",
+            "name": "nginx",
             "state": {
               "running": {
-                "startedAt": "2017-11-27T19:47:00Z"
+                "startedAt": "2023-10-01T12:01:00Z"
               }
             },
-            "lastState": {},
             "ready": true,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/enimanager:2342384234234njadsh23j42h3424234gh23g4j2g34",
-            "imageID": "docker-pullable://1234567890.cloud-url/enimanager@sha256:472bb17b34ad49d16a05f5cd8f7c9b046578edbebb63925ac7bf72dfca20104b",
-            "containerID": "docker://d035782b2429893dc45618e0375a2409c22a8cd239ff9c0c446cb429b5a35b5c"
+            "image": "nginx:latest",
+            "imageID": "docker://sha256:abc123def456..."
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "zk-update-monitor-r1vlt",
-        "generateName": "zk-update-monitor-",
+        "name": "nginx-deployment-5c689d7589-fghij",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/zk-update-monitor-r1vlt",
-        "uid": "7d1d8b00-b532-11e7-b628-0674200569b6",
-        "resourceVersion": "32518932",
-        "creationTimestamp": "2017-10-20T01:03:31Z",
-        "labels": {
-          "controller-revision-hash": "4079167259",
-          "name": "zk-update-monitor",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858402679Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"zk-update-monitor\",\"uid\":\"fe580c9c-b092-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"12847168\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "zk-update-monitor",
-            "uid": "fe580c9c-b092-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "cellzkhosts",
-            "hostPath": {
-              "path": "/etc/cell_zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "zkhosts",
-            "hostPath": {
-              "path": "/etc/zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log/zk_update_monitor"
-            }
-          },
-          {
-            "name": "downloadmeta",
-            "hostPath": {
-              "path": "/var/zum_download_meta"
-            }
-          },
-          {
-            "name": "zumconfig",
-            "hostPath": {
-              "path": "/etc/zk_update_monitor.d"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "zk-update-monitor",
-            "image": "1234567890.cloud-url/zk-update-monitor:e11b8230120d18315e87092e45a3ecfd101c2977",
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "cellzkhosts",
-                "mountPath": "/etc/cell_zookeeper_hosts.conf"
-              },
-              {
-                "name": "zkhosts",
-                "mountPath": "/etc/zookeeper_hosts.conf"
-              },
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log/zk_update_monitor"
-              },
-              {
-                "name": "downloadmeta",
-                "mountPath": "/var/zum_download_meta"
-              },
-              {
-                "name": "zumconfig",
-                "mountPath": "/etc/zk_update_monitor.d"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
+        "uid": "12345678-1234-5678-1234-567890abcdef"
       },
       "status": {
         "phase": "Running",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-20T01:03:35Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2018-02-07T08:45:17Z"
+            "status": "True"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-20T01:03:49Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-20T01:03:35Z",
+        "hostIP": "192.168.0.2",
+        "podIP": "10.0.0.2",
+        "startTime": "2023-10-01T12:05:00Z",
         "containerStatuses": [
           {
-            "name": "zk-update-monitor",
+            "name": "nginx",
             "state": {
               "running": {
-                "startedAt": "2018-02-07T08:45:16Z"
+                "startedAt": "2023-10-01T12:06:00Z"
               }
             },
-            "lastState": {
-              "terminated": {
-                "exitCode": 137,
-                "reason": "Error",
-                "startedAt": "2018-02-06T07:57:00Z",
-                "finishedAt": "2018-02-07T08:45:15Z",
-                "containerID": "docker://f1713cb43857ba2bea8194362085bf2b4ad5e603d80ce37a0810e28b04e07337"
-              }
-            },
-            "ready": true,
-            "restartCount": 103,
-            "image": "1234567890.cloud-url/zk-update-monitor:e11b8230120d18315e87092e45a3ecfd101c2977",
-            "imageID": "docker-pullable://1234567890.cloud-url/zk-update-monitor@sha256:39411011296a7c0dbd1b22e56adca073a1801d3c036dfa1fb10e7aa475420406",
-            "containerID": "docker://a4be6120aefe99721ba48525be5d4076e06933aa8b5b2d2da8351675aac13a59"
-          }
-        ],
-        "qosClass": "BestEffort"
-      }
-    },
-    {
-      "metadata": {
-        "name": "tcollector-q4qx8",
-        "generateName": "tcollector-",
-        "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/tcollector-q4qx8",
-        "uid": "8ad2dba8-b84c-11e7-b628-0674200569b6",
-        "resourceVersion": "17165145",
-        "creationTimestamp": "2017-10-23T23:47:34Z",
-        "labels": {
-          "controller-revision-hash": "45790700",
-          "name": "tcollector",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858411903Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"tcollector\",\"uid\":\"8ad12af5-b84c-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17164414\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "tcollector",
-            "uid": "8ad12af5-b84c-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "cellzkhosts",
-            "hostPath": {
-              "path": "/etc/cell_zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "zkhosts",
-            "hostPath": {
-              "path": "/etc/zookeeper_hosts.conf"
-            }
-          },
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "run",
-            "hostPath": {
-              "path": "/run"
-            }
-          },
-          {
-            "name": "cgroup",
-            "hostPath": {
-              "path": "/sys/fs/cgroup"
-            }
-          },
-          {
-            "name": "deployd",
-            "hostPath": {
-              "path": "/mnt/deployd"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "tcollector",
-            "image": "1234567890.cloud-url/tcollector:763db0abff6ead4afe4aed15124f6fe4ca7dc295",
-            "env": [
-              {
-                "name": "LOGFILE",
-                "value": "/var/log/tcollector.log"
-              },
-              {
-                "name": "PIDFILE",
-                "value": "/var/run/tcollector.log"
-              },
-              {
-                "name": "HOST",
-                "value": "$HOSTNAME"
-              },
-              {
-                "name": "CLUSTER",
-                "value": "k8sworker"
-              },
-              {
-                "name": "EC2_ZONE",
-                "value": "us-east-1e"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "cellzkhosts",
-                "mountPath": "/etc/cell_zookeeper_hosts.conf"
-              },
-              {
-                "name": "zkhosts",
-                "mountPath": "/etc/zookeeper_hosts.conf"
-              },
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "run",
-                "mountPath": "/run"
-              },
-              {
-                "name": "cgroup",
-                "mountPath": "/sys/fs/cgroup"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "deployd",
-                "mountPath": "/mnt/deployd"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
-      },
-      "status": {
-        "phase": "Running",
-        "conditions": [
-          {
-            "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:34Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:35Z"
-          },
-          {
-            "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-23T23:47:35Z"
-          }
-        ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-23T23:47:34Z",
-        "containerStatuses": [
-          {
-            "name": "tcollector",
-            "state": {
-              "running": {
-                "startedAt": "2017-10-23T23:47:35Z"
-              }
-            },
-            "lastState": {},
             "ready": true,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/tcollector:763db0abff6ead4afe4aed15124f6fe4ca7dc295",
-            "imageID": "docker-pullable://1234567890.cloud-url/tcollector@sha256:a180b767f8fc13b7eadf7890d969dcefc154c90ba7565c4269f80926d3e92338",
-            "containerID": "docker://56336c15058d46041e8977a932039c68f9fe5ea7a1f14415a5f7d316da3c9911"
+            "image": "nginx:latest",
+            "imageID": "docker://sha256:abc123def456..."
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "metrics-agent-8vm9g",
-        "generateName": "metrics-agent-",
+        "name": "backend-service-7987d5b5c-12345",
         "namespace": "default",
-        "selfLink": "/api/v1/namespaces/default/pods/metrics-agent-8vm9g",
-        "uid": "bfc5f760-b8e1-11e7-b628-0674200569b6",
-        "resourceVersion": "17608680",
-        "creationTimestamp": "2017-10-24T17:35:38Z",
-        "labels": {
-          "controller-revision-hash": "4410873",
-          "name": "metrics-agent",
-          "pod-template-generation": "1"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.85838677Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"metrics-agent\",\"uid\":\"bfc3d9c0-b8e1-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17608014\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "DaemonSet",
-            "name": "metrics-agent",
-            "uid": "bfc3d9c0-b8e1-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "config",
-            "hostPath": {
-              "path": "/var/config"
-            }
-          },
-          {
-            "name": "serverset",
-            "hostPath": {
-              "path": "/var/serverset"
-            }
-          },
-          {
-            "name": "log",
-            "hostPath": {
-              "path": "/var/log"
-            }
-          },
-          {
-            "name": "varrun",
-            "hostPath": {
-              "path": "/var/run"
-            }
-          },
-          {
-            "name": "default-token-9sqmj",
-            "secret": {
-              "secretName": "default-token-9sqmj",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "metrics-agent",
-            "image": "1234567890.cloud-url/metrics-agent:87155c18715c3e12301e42ec6cb6f9f5bb3c1e36",
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "config",
-                "mountPath": "/var/config"
-              },
-              {
-                "name": "serverset",
-                "mountPath": "/var/serverset"
-              },
-              {
-                "name": "varrun",
-                "mountPath": "/var/run"
-              },
-              {
-                "name": "log",
-                "mountPath": "/var/log"
-              },
-              {
-                "name": "default-token-9sqmj",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "default",
-        "serviceAccount": "default",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute"
-          }
-        ]
+        "uid": "54321678-9876-5432-9876-5432198765ac"
       },
       "status": {
-        "phase": "Running",
+        "phase": "Pending",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:38Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:47Z"
+            "status": "True"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-24T17:35:47Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-24T17:35:38Z",
+        "hostIP": "192.168.0.3",
+        "startTime": "2023-10-01T13:00:00Z",
         "containerStatuses": [
           {
-            "name": "metrics-agent",
+            "name": "backend",
             "state": {
-              "running": {
-                "startedAt": "2017-10-24T17:35:46Z"
+              "waiting": {
+                "reason": "ContainerCreating"
               }
             },
-            "lastState": {},
-            "ready": true,
+            "ready": false,
             "restartCount": 0,
-            "image": "1234567890.cloud-url/metrics-agent:87155c18715c3e12301e42ec6cb6f9f5bb3c1e36",
-            "imageID": "docker-pullable://1234567890.cloud-url/metrics-agent@sha256:b330453145957f8cdee90ac47ea8e214175a6aba1bca95bc142ae35fa50d964e",
-            "containerID": "docker://6a920a80a3b9892e957ec45dfd86936bded1b43a0ca16863e42afadc17951731"
+            "image": "backend:latest"
           }
-        ],
-        "qosClass": "BestEffort"
+        ]
       }
     },
     {
       "metadata": {
-        "name": "kubernetes-dashboard-1835568627-hhfhj",
-        "generateName": "kubernetes-dashboard-1835568627-",
-        "namespace": "kube-system",
-        "selfLink": "/api/v1/namespaces/kube-system/pods/kubernetes-dashboard-1835568627-hhfhj",
-        "uid": "a343643b-b936-11e7-b628-0674200569b6",
-        "resourceVersion": "17831826",
-        "creationTimestamp": "2017-10-25T03:43:17Z",
-        "labels": {
-          "k8s-app": "kubernetes-dashboard",
-          "pod-template-hash": "1835568627"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.85842129Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"kube-system\",\"name\":\"kubernetes-dashboard-1835568627\",\"uid\":\"a3427a70-b936-11e7-b628-0674200569b6\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"17831783\"}}\n"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "extensions/v1beta1",
-            "kind": "ReplicaSet",
-            "name": "kubernetes-dashboard-1835568627",
-            "uid": "a3427a70-b936-11e7-b628-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "tempvol",
-            "emptyDir": {
-              "sizeLimit": "0"
-            }
-          },
-          {
-            "name": "kubernetes-dashboard-token-mz6xk",
-            "secret": {
-              "secretName": "kubernetes-dashboard-token-mz6xk",
-              "defaultMode": 420
-            }
-          }
-        ],
-        "containers": [
-          {
-            "name": "kubernetes-dashboard",
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1",
-            "args": [
-              "--apiserver-host=http://10.1.100.201:8080"
-            ],
-            "ports": [
-              {
-                "hostPort": 9090,
-                "containerPort": 9090,
-                "protocol": "TCP"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "tempvol",
-                "mountPath": "/tmp"
-              },
-              {
-                "name": "kubernetes-dashboard-token-mz6xk",
-                "readOnly": true,
-                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
-              }
-            ],
-            "livenessProbe": {
-              "httpGet": {
-                "path": "/",
-                "port": 9090,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 30,
-              "timeoutSeconds": 30,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 30,
-        "dnsPolicy": "ClusterFirst",
-        "serviceAccountName": "kubernetes-dashboard",
-        "serviceAccount": "kubernetes-dashboard",
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "schedulerName": "default-scheduler",
-        "tolerations": [
-          {
-            "key": "node-role.kubernetes.io/master",
-            "effect": "NoSchedule"
-          },
-          {
-            "key": "node.alpha.kubernetes.io/notReady",
-            "operator": "Exists",
-            "effect": "NoExecute",
-            "tolerationSeconds": 300
-          },
-          {
-            "key": "node.alpha.kubernetes.io/unreachable",
-            "operator": "Exists",
-            "effect": "NoExecute",
-            "tolerationSeconds": 300
-          }
-        ]
+        "name": "frontend-service-7f8d5b7c6-xzywv",
+        "namespace": "default",
+        "uid": "54321098-7654-3210-6798-5432123456dc"
       },
       "status": {
-        "phase": "Running",
+        "phase": "Succeeded",
         "conditions": [
           {
             "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:17Z"
+            "status": "True"
           },
           {
             "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:21Z"
+            "status": "False"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False"
           },
           {
             "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-10-25T03:43:17Z"
+            "status": "True"
           }
         ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-10-25T03:43:17Z",
+        "hostIP": "192.168.0.4",
+        "startTime": "2023-10-01T14:00:00Z",
         "containerStatuses": [
           {
-            "name": "kubernetes-dashboard",
-            "state": {
-              "running": {
-                "startedAt": "2017-10-25T03:43:21Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "gcr.io/google_containers/kubernetes-dashboard-amd64:v1.7.1",
-            "imageID": "docker-pullable://gcr.io/google_containers/kubernetes-dashboard-amd64@sha256:327cfef378e88ffbc327f98dd24adacf6c9363c042db78e922d050f2bdcf6f78",
-            "containerID": "docker://82d3c78b28bdd202c401005b130d6550673f5d541cc4d1396e521f348e6bc94d"
-          }
-        ],
-        "qosClass": "BestEffort"
-      }
-    },
-    {
-      "metadata": {
-        "name": "test-ci-0",
-        "generateName": "test-ci-",
-        "namespace": "kubernetes-plugin",
-        "selfLink": "/api/v1/namespaces/kubernetes-plugin/pods/test-ci-0",
-        "uid": "f084af12-cbe6-11e7-a1db-0674200569b6",
-        "resourceVersion": "33082906",
-        "creationTimestamp": "2017-11-17T22:30:39Z",
-        "labels": {
-          "controller-revision-hash": "test-ci-2949316050",
-          "name": "test-ci"
-        },
-        "annotations": {
-          "kubernetes.io/config.seen": "2017-11-27T19:44:45.858430027Z",
-          "kubernetes.io/config.source": "api",
-          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"StatefulSet\",\"namespace\":\"kubernetes-plugin\",\"name\":\"test-ci\",\"uid\":\"c41c7d07-cbe5-11e7-a1db-0674200569b6\",\"apiVersion\":\"apps/v1beta1\",\"resourceVersion\":\"26293887\"}}\n",
-          "pod.alpha.kubernetes.io/init-container-statuses": "[{\"name\":\"init-jenkins-home\",\"state\":{\"terminated\":{\"exitCode\":0,\"reason\":\"Completed\",\"startedAt\":\"2017-11-17T22:30:40Z\",\"finishedAt\":\"2017-11-17T22:30:40Z\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}},\"lastState\":{},\"ready\":true,\"restartCount\":0,\"image\":\"busybox:latest\",\"imageID\":\"docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}]",
-          "pod.alpha.kubernetes.io/init-containers": "[{\"name\":\"init-jenkins-home\",\"image\":\"busybox\",\"command\":[\"sh\",\"-c\",\"chmod 777 /var/jenkins_home\"],\"resources\":{},\"volumeMounts\":[{\"name\":\"jenkins-home\",\"mountPath\":\"/var/jenkins_home\"}],\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"Always\"}]",
-          "pod.beta.kubernetes.io/init-container-statuses": "[{\"name\":\"init-jenkins-home\",\"state\":{\"terminated\":{\"exitCode\":0,\"reason\":\"Completed\",\"startedAt\":\"2017-11-17T22:30:40Z\",\"finishedAt\":\"2017-11-17T22:30:40Z\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}},\"lastState\":{},\"ready\":true,\"restartCount\":0,\"image\":\"busybox:latest\",\"imageID\":\"docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0\",\"containerID\":\"docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848\"}]",
-          "pod.beta.kubernetes.io/init-containers": "[{\"name\":\"init-jenkins-home\",\"image\":\"busybox\",\"command\":[\"sh\",\"-c\",\"chmod 777 /var/jenkins_home\"],\"resources\":{},\"volumeMounts\":[{\"name\":\"jenkins-home\",\"mountPath\":\"/var/jenkins_home\"}],\"terminationMessagePath\":\"/dev/termination-log\",\"terminationMessagePolicy\":\"File\",\"imagePullPolicy\":\"Always\"}]"
-        },
-        "ownerReferences": [
-          {
-            "apiVersion": "apps/v1beta1",
-            "kind": "StatefulSet",
-            "name": "test-ci",
-            "uid": "c41c7d07-cbe5-11e7-a1db-0674200569b6",
-            "controller": true,
-            "blockOwnerDeletion": true
-          }
-        ]
-      },
-      "spec": {
-        "volumes": [
-          {
-            "name": "jenkins-home",
-            "hostPath": {
-              "path": "/jenkins/jenkinsmaster"
-            }
-          },
-          {
-            "name": "knox-bin",
-            "hostPath": {
-              "path": "/usr/bin/knox"
-            }
-          },
-          {
-            "name": "knox-lib",
-            "hostPath": {
-              "path": "/var/lib/knox"
-            }
-          },
-          {
-            "name": "normandie",
-            "hostPath": {
-              "path": "/var/lib/normandie"
-            }
-          }
-        ],
-        "initContainers": [
-          {
-            "name": "init-jenkins-home",
-            "image": "busybox",
-            "command": [
-              "sh",
-              "-c",
-              "chmod 777 /var/jenkins_home"
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "jenkins-home",
-                "mountPath": "/var/jenkins_home"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          }
-        ],
-        "containers": [
-          {
-            "name": "oauth-proxy",
-            "image": "1234567890.cloud-url/nginx-oauth-proxy:latest",
-            "ports": [
-              {
-                "hostPort": 80,
-                "containerPort": 80,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "SERVICE",
-                "value": "jenkins"
-              },
-              {
-                "name": "PROXY_PORT",
-                "value": "8080"
-              },
-              {
-                "name": "CALLBACK_HOST",
-                "value": "test-ci.sample.com"
-              }
-            ],
-            "resources": {},
-            "volumeMounts": [
-              {
-                "name": "knox-bin",
-                "mountPath": "/usr/bin/knox"
-              },
-              {
-                "name": "knox-lib",
-                "mountPath": "/var/lib/knox"
-              },
-              {
-                "name": "normandie",
-                "mountPath": "/var/lib/normandie"
-              }
-            ],
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "Always"
-          },
-          {
-            "name": "test-ci",
-            "image": "1234567890.cloud-url/jenkins:jenkins-master",
-            "ports": [
-              {
-                "hostPort": 8080,
-                "containerPort": 8080,
-                "protocol": "TCP"
-              },
-              {
-                "hostPort": 50000,
-                "containerPort": 50000,
-                "protocol": "TCP"
-              }
-            ],
-            "env": [
-              {
-                "name": "JAVA_OPTS",
-                "value": "-Dorg.apache.commons.jelly.tags.fmt.timeZone=America/Los_Angeles -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1 -Dhudson.slaves.NodeProvisioner.MARGIN=50 -Dhudson.slaves.NodeProvisioner.MARGIN0=0.85 -Dhudson.slaves.NodeProvisioner.initialDelay=0 -Dhudson.slaves.NodeProvisioner.recurrencePeriod=5000"
-              }
-            ],
-            "resources": {
-              "limits": {
-                "cpu": "30"
-              },
-              "requests": {
-                "cpu": "30"
-              }
-            },
-            "volumeMounts": [
-              {
-                "name": "jenkins-home",
-                "mountPath": "/var/jenkins_home"
-              }
-            ],
-            "livenessProbe": {
-              "httpGet": {
-                "path": "/login",
-                "port": 8080,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 60,
-              "timeoutSeconds": 5,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "readinessProbe": {
-              "httpGet": {
-                "path": "/login",
-                "port": 8080,
-                "scheme": "HTTP"
-              },
-              "initialDelaySeconds": 5,
-              "timeoutSeconds": 5,
-              "periodSeconds": 10,
-              "successThreshold": 1,
-              "failureThreshold": 3
-            },
-            "terminationMessagePath": "/dev/termination-log",
-            "terminationMessagePolicy": "File",
-            "imagePullPolicy": "IfNotPresent"
-          }
-        ],
-        "restartPolicy": "Always",
-        "terminationGracePeriodSeconds": 1,
-        "dnsPolicy": "ClusterFirst",
-        "nodeSelector": {
-          "jenkins/node": "test-ci"
-        },
-        "nodeName": "ip-10-1-161-13.ec2.internal",
-        "hostNetwork": true,
-        "securityContext": {},
-        "hostname": "test-ci-0",
-        "subdomain": "test-ci",
-        "schedulerName": "default-scheduler"
-      },
-      "status": {
-        "phase": "Running",
-        "conditions": [
-          {
-            "type": "Initialized",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-17T22:30:41Z"
-          },
-          {
-            "type": "Ready",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-27T19:44:54Z"
-          },
-          {
-            "type": "PodScheduled",
-            "status": "True",
-            "lastProbeTime": null,
-            "lastTransitionTime": "2017-11-17T22:30:39Z"
-          }
-        ],
-        "hostIP": "10.1.161.13",
-        "podIP": "10.1.161.13",
-        "startTime": "2017-11-17T22:30:39Z",
-        "initContainerStatuses": [
-          {
-            "name": "init-jenkins-home",
+            "name": "frontend",
             "state": {
               "terminated": {
                 "exitCode": 0,
                 "reason": "Completed",
-                "startedAt": "2017-11-17T22:30:40Z",
-                "finishedAt": "2017-11-17T22:30:40Z",
-                "containerID": "docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848"
+                "finishedAt": "2023-10-01T14:30:00Z"
               }
             },
-            "lastState": {},
-            "ready": true,
+            "ready": false,
             "restartCount": 0,
-            "image": "busybox:latest",
-            "imageID": "docker-pullable://busybox@sha256:bbc3a03235220b170ba48a157dd097dd1379299370e1ed99ce976df0355d24f0",
-            "containerID": "docker://260c65a21b0ec71ea9738e7db6bf2f1877f3407aceb78d7b1e26b7a4fdbe8848"
+            "image": "frontend:latest",
+            "imageID": "docker://sha256:abcdef123456..."
           }
-        ],
-        "containerStatuses": [
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "database-7f8d5b7c6-mnopq",
+        "namespace": "default",
+        "uid": "98765432-7654-4321-6543-987654321098"
+      },
+      "status": {
+        "phase": "Failed",
+        "conditions": [
           {
-            "name": "oauth-proxy",
-            "state": {
-              "running": {
-                "startedAt": "2017-11-18T10:17:24Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "1234567890.cloud-url/nginx-oauth-proxy:latest",
-            "imageID": "docker-pullable://1234567890.cloud-url/nginx-oauth-proxy@sha256:16c4e8a21455f206cb4051de25a9e58a654743f4c57ed78d99a679a112f316c9",
-            "containerID": "docker://173b2e01223e4c0f3754f84da4c9685645cf0392bf44f1687bf871860c222276"
+            "type": "Initialized",
+            "status": "True"
           },
           {
-            "name": "test-ci",
-            "state": {
-              "running": {
-                "startedAt": "2017-11-27T18:58:05Z"
-              }
-            },
-            "lastState": {},
-            "ready": true,
-            "restartCount": 0,
-            "image": "1234567890.cloud-url/jenkins:jenkins-master",
-            "imageID": "docker-pullable://1234567890.cloud-url/jenkins@sha256:9fdb938c6a1e343429eabcf44626ff326fbaa8fa7e672257eaa3fd9018471021",
-            "containerID": "docker://5cadd5f06d30664513aa97639a2433775c1364b516f05c2203bec9be4b8a8956"
+            "type": "Ready",
+            "status": "False"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "False"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True"
           }
         ],
-        "qosClass": "Burstable"
+        "hostIP": "192.168.0.5",
+        "startTime": "2023-10-01T15:00:00Z",
+        "containerStatuses": [
+          {
+            "name": "database",
+            "state": {
+              "terminated": {
+                "exitCode": 1,
+                "reason": "Error",
+                "message": "CrashLoopBackOff",
+                "finishedAt": "2023-10-01T15:30:00Z"
+              }
+            },
+            "ready": false,
+            "restartCount": 3,
+            "image": "database:latest",
+            "imageID": "docker://sha256:123456abcdef..."
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "analytics-57c66b48c6-qwer7",
+        "namespace": "default",
+        "uid": "09876543-7654-5432-8765-098765432109"
+      },
+      "status": {
+        "phase": "Unknown",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "Unknown"
+          },
+          {
+            "type": "Ready",
+            "status": "Unknown"
+          },
+          {
+            "type": "ContainersReady",
+            "status": "Unknown"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "Unknown"
+          }
+        ],
+        "hostIP": "192.168.0.6",
+        "startTime": "2023-10-01T16:00:00Z",
+        "containerStatuses": [
+          {
+            "name": "analytics",
+            "state": {
+              "waiting": {
+                "reason": "Unknown"
+              }
+            },
+            "ready": false,
+            "restartCount": 0,
+            "image": "analytics:beta",
+            "imageID": ""
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Introducing a new singleton class `PodMetadataWatcher` that implements the `PodWatcher` interface. Whenever a pod is created or deleted, this class will query Kubelet to parse the pod's metadata and store it in a map. Since this watcher is registered before LogStreamManager, the metadata for each pod should be fresh whenever each log stream is created. 

We also add a new `podMetadata` field to `SingerLog` to attach pod metadata per log in k8s mode.

The pod metadata to track is defined by:

```
  7: optional list<string> podMetadataFields;
```
