### PR TITLE
Add support for environment account id

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/environment/EnvVariableBasedEnvironmentProvider.java
+++ b/singer/src/main/java/com/pinterest/singer/environment/EnvVariableBasedEnvironmentProvider.java
@@ -23,6 +23,7 @@ public class EnvVariableBasedEnvironmentProvider extends EnvironmentProvider {
 
   private static final String DEPLOYMENT_STAGE = "DEPLOYMENT_STAGE";
   private static final String LOCALITY = "LOCALITY";
+  private static final String ACCOUNT_ID = "ACCOUNT_ID";
 
   @Override
   protected String getLocality() {
@@ -32,6 +33,12 @@ public class EnvVariableBasedEnvironmentProvider extends EnvironmentProvider {
     } else {
       return Environment.LOCALITY_NOT_AVAILABLE;
     }
+  }
+
+  @Override
+  protected String getAccountId() {
+    String accountId = System.getenv(ACCOUNT_ID);
+    return accountId != null ? accountId : "n/a";
   }
 
   @Override

--- a/singer/src/main/java/com/pinterest/singer/environment/Environment.java
+++ b/singer/src/main/java/com/pinterest/singer/environment/Environment.java
@@ -30,6 +30,8 @@ public class Environment {
 
   public static final String LOCALITY_NOT_AVAILABLE = "n/a";
   public static final String DEFAULT_HOSTNAME = SingerUtils.getHostname();
+  // Useful to track when running in cloud environments
+  private String accountId;
   private String locality = LOCALITY_NOT_AVAILABLE;
   private String deploymentStage;
   private String hostname = DEFAULT_HOSTNAME;
@@ -46,6 +48,20 @@ public class Environment {
    */
   public void setLocality(String locality) {
     this.locality = locality;
+  }
+
+  /**
+   * @param accountId the accountId to set
+   */
+  public void setAccountId(String accountId) {
+    this.accountId = accountId;
+  }
+
+  /**
+   * @return the accountId
+   */
+  public String getAccountId() {
+    return accountId;
   }
 
   /**
@@ -82,7 +98,7 @@ public class Environment {
   @Override
   public String toString() {
     return "Environment [locality=" + locality + ", deploymentStage=" + deploymentStage
-        + ", hostname=" + hostname + "]";
+        + ", hostname=" + hostname + ", accountId=" + accountId + "]";
   }
 
 }

--- a/singer/src/main/java/com/pinterest/singer/environment/EnvironmentProvider.java
+++ b/singer/src/main/java/com/pinterest/singer/environment/EnvironmentProvider.java
@@ -25,11 +25,14 @@ public abstract class EnvironmentProvider {
   
   public EnvironmentProvider() {
     environment.setDeploymentStage(getDeploymentStage());
+    environment.setAccountId(getAccountId());
     environment.setLocality(getLocality());
     environment.setHostname(getHostname());
   }
   
   protected abstract String getLocality();
+
+  protected abstract String getAccountId();
 
   protected abstract String getDeploymentStage();
   

--- a/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/TextLogFileReader.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.reader;
 
 import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.LogMessage;
@@ -100,6 +101,8 @@ public class TextLogFileReader implements LogFileReader {
       headers.put("hostname", SingerUtils.getByteBuf(hostname));
       headers.put("file", SingerUtils.getByteBuf(path));
       headers.put("availabilityZone", SingerUtils.getByteBuf(availabilityZone));
+      headers.put("accountId",
+          SingerUtils.getByteBuf(SingerSettings.getEnvironment().getAccountId()));
       Map<String, ByteBuffer> logMetadata = logStream.getSingerLog().getPodMetadata();
       if (logMetadata != null && !logMetadata.isEmpty()) {
         headers.putAll(logMetadata);

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.reader;
 
 import com.pinterest.singer.common.LogStream;
+import com.pinterest.singer.common.SingerSettings;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogFile;
 import com.pinterest.singer.thrift.LogMessage;
@@ -110,6 +111,8 @@ public class ThriftLogFileReader implements LogFileReader {
       headers.put("hostname", SingerUtils.getByteBuf(hostname));
       headers.put("file", SingerUtils.getByteBuf(path));
       headers.put("availabilityZone", SingerUtils.getByteBuf(availabilityZone));
+      headers.put("accountId",
+          SingerUtils.getByteBuf(SingerSettings.getEnvironment().getAccountId()));
       Map<String, ByteBuffer> logMetadata = logStream.getSingerLog().getPodMetadata();
       if (logMetadata != null && !logMetadata.isEmpty()) {
         headers.putAll(logMetadata);


### PR DESCRIPTION
Integrate an "accountId" field into the Environment class to allow cloud-based environment providers to track it.