### PR TITLE
High tag cardinality metrics changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.94</version>
+    <version>0.8.0.95</version>
     <packaging>pom</packaging>
     <description>Singer Logging Agent modules</description>
     <inceptionYear>2013</inceptionYear>

--- a/singer-commons/pom.xml
+++ b/singer-commons/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.94</version>
+    <version>0.8.0.95</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <developers>

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.pinterest.singer</groupId>
         <artifactId>singer-package</artifactId>
-        <version>0.8.0.94</version>
+        <version>0.8.0.95</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <licenses>

--- a/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
+++ b/singer/src/main/java/com/pinterest/singer/monitor/LogStreamManager.java
@@ -722,7 +722,6 @@ public class LogStreamManager implements PodWatcher {
           Map<String, String> podMetadata = PodMetadataWatcher.getInstance().getPodMetadata(podUid);
           if (podMetadata != null) {
             LOG.info("Initializing pod metadata {} for pod: {}", podMetadata, podUid);
-            OpenTsdbMetricConverter.incr("pod_metadata_enabled", 1, "pod=" + podUid, "log=" + clone.getName());
             for (Map.Entry<String, String> entry : podMetadata.entrySet()) {
               singerLog.addMetadata(entry.getKey(), SingerUtils.getByteBuf(entry.getValue()));
             }

--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
@@ -153,7 +153,7 @@ public class ThriftLogFileReader implements LogFileReader {
         if (messageSize > maxMessageSize) {
           LOG.warn("Found a message at offset " + newByteOffset + "that exceeds the size limit in "
               + logFile.toString() + ": messageSize =  " + messageSize);
-          OpenTsdbMetricConverter.incr("singer.thrift_reader.skip_message", 1, "path=" + path, "log=" + logStream.getSingerLog().getLogName());
+          OpenTsdbMetricConverter.incr("singer.thrift_reader.skip_message", 1, "log=" + logStream.getSingerLog().getLogName());
           logMessage = thriftReader.read();
         } else {
           LogPosition position = new LogPosition(logFile, newByteOffset);

--- a/thrift-logger/pom.xml
+++ b/thrift-logger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.pinterest.singer</groupId>
     <artifactId>singer-package</artifactId>
-    <version>0.8.0.94</version>
+    <version>0.8.0.95</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>thrift-logger</artifactId>


### PR DESCRIPTION
`pod_metadata_enabled`  is not correctly formatted with singer namespace prefix and can get have high cardinality when running in k8s.

path tag in `singer.thrift_reader.skip_message` can also lead to high tag cardinality.

Bumping version to `0.8.0.95`
