### PR TITLE
Allow multiple directories per log config

### DIFF
--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -96,6 +96,11 @@
             <version>1.10.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
             <version>${netty.version}</version>

--- a/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/DefaultLogStreamProcessor.java
@@ -467,7 +467,7 @@ public class DefaultLogStreamProcessor implements LogStreamProcessor, Runnable {
    * @return
    */
   static String getWatermarkFilename(LogStream logStream) {
-    String path = logStream.getSingerLog().getSingerLogConfig().getLogDir();
+    String path = logStream.getLogDir();
     // Get the globally unique watermark file name
     String watermarkFilename = "." + logStream.getSingerLog().getLogName()
         + "." + logStream.getLogStreamName();

--- a/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/SingerUtils.java
@@ -370,6 +370,88 @@ public class SingerUtils {
       }
     }
   }
+
+  /**
+   * Helper function to turn a list of directories as a String into an ArrayList of String directories ignoring
+   * whitespace as well
+   * ie) "/dir1, /dir2,   /dir3" -> ["/dir1", "/dir2", "/dir3"]
+   * @param input
+   * @return ArrayList of directories
+   * */
+  public static ArrayList<String> splitString(String input) {
+    input = input.replaceAll("\\s+", "");
+    String[] splitArray = input.split(",\\s*");
+    return new ArrayList<>(Arrays.asList(splitArray));
+  }
+
+
+  /**
+   * Helper function to concatenate a list of directories with a given prefix
+   * ie) ["/dir1", "/dir2", "/dir3"], "file" -> ["/dir1/file", "/dir2/file", "/dir3/file"]
+   * @param directories
+   * @param fileNamePrefix
+   * @return ArrayList of directories
+   * */
+  public static ArrayList<String> concatenateDirectories(ArrayList<String> directories, String fileNamePrefix) {
+    ArrayList<String> concatenatedFileNames = new ArrayList<>();
+    for (String directory : directories) {
+      String concatenatedFileName = directory + "/" + fileNamePrefix;
+      concatenatedFileNames.add(concatenatedFileName);
+    }
+    return concatenatedFileNames;
+  }
+
+  /**
+   * Helper function to extract the directory path from a file path
+   */
+  public static String extractDirectoryPath(String filePath) {
+    // Check if the filePath ends with a file name
+    int index = filePath.lastIndexOf("/");
+    if (index >= 0) {
+      // Extract the directory path from the filePath
+      String directoryPath = filePath.substring(0, index);
+      return directoryPath;
+    } else {
+      return null; // No directory path found
+    }
+  }
+
+
+  /**
+   * Helper function to see if all directories exist
+   * */
+  public static boolean allDirectoriesExist(ArrayList<String> directories) {
+    for (String directory : directories) {
+      File dir = new File(directory);
+      if (!dir.exists()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+
+  /**
+   * Function to modify the file path by removing `/var/logs` and adding the podUid.
+   *
+   * @param file The file object with the original path.
+   * @param podUid The podUid string.
+   * @return A modified path string.
+   */
+  public static String getModifiedFilePath(File file, String podUid) {
+    String originalPath = file.getAbsolutePath();
+    String targetPrefix = "/var/logs";
+
+    // Check if the original path ends with the target prefix
+    if (originalPath.endsWith(targetPrefix)) {
+      // Remove the target prefix
+      originalPath = originalPath.substring(0, originalPath.length() - targetPrefix.length());
+    }
+
+    // Return the modified path
+    return originalPath + podUid + "/";
+  }
+
   @VisibleForTesting
   public static void setHostname(String hostname, String regex) {
     HOSTNAME = hostname;

--- a/singer/src/test/java/com/pinterest/singer/monitor/LogDirectoryScannerTest.java
+++ b/singer/src/test/java/com/pinterest/singer/monitor/LogDirectoryScannerTest.java
@@ -45,7 +45,10 @@ public class LogDirectoryScannerTest extends com.pinterest.singer.SingerTestBase
     System.out.println("testDir: " + testDir.getPath());
     SingerLogConfig singerLogConfig = createSingerLogConfig("test", testDir.getPath());
     SingerLog singerLog = new SingerLog(singerLogConfig);
-    LogStream logStream = LogStreamManager.createNewLogStream(singerLog, filePrefix);
+    LogStream
+        logStream =
+        LogStreamManager.createNewLogStream(singerLog,
+            new File(testDir + "/" + filePrefix).toPath());
     return logStream;
   }
 


### PR DESCRIPTION
Adding support for wildcard use in all parts of directory configs, it currently is limited to only last part of directory string. In addition, refactoring certain part of the code structure to improve readability. List of main changes:

- Change `logConfigMap` to use `Pair<>` for keys: This map is essentially only used in Kubernetes mode by `RecursiveFSEventProcessor`. During the pod directory traversal, we use this map to determine if there are any configs left for directories in a sublevel. Now that we have wildcards in the directory names, we can no longer use `subMap()` function reliably. Thus, we change the approach to directly use directory depth for this purpose. The Pair consists of directory depth (for ordering) and directory (for tracking, can contain wildcard).

- Change approach for Wildcard matching: Before we use to translate the wildcards to regex pattern, now we use Apache Commons `FilenameUtils.wildcardMatch` + Files.walkFileTree for traversal, which should be a bit more efficient than using  regex.

- MissingDirChecker: Removed extra data structure to hold wildcard directories, now we combine them into the existing map and perform dynamic discovery for wildcard directories only.

Tested the following scenarios in devapp:

1. No wildcard directories and single directory (standard use case checking for regression)
2. Wildcard directory + no wildcard directory
3. Wildcard directory only
4. Wildcard directory dynamic discovery: Create directory and make sure Singer picks it up
