### PR TITLE
Improve message size warn message

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
+++ b/singer/src/main/java/com/pinterest/singer/reader/ThriftLogFileReader.java
@@ -151,8 +151,8 @@ public class ThriftLogFileReader implements LogFileReader {
         long newByteOffset = thriftReader.getByteOffset();
         int messageSize = logMessage.getMessage().length;
         if (messageSize > maxMessageSize) {
-          LOG.warn("Found a message at offset " + newByteOffset + "that exceeds the size limit in "
-              + logFile.toString() + ": messageSize =  " + messageSize);
+          LOG.warn("Found a message at offset " + newByteOffset + " that exceeds the size limit in log file: "
+              + logStream.getFullPathPrefix() + " with messageSize =  " + messageSize);
           OpenTsdbMetricConverter.incr("singer.thrift_reader.skip_message", 1, "log=" + logStream.getSingerLog().getLogName());
           logMessage = thriftReader.read();
         } else {


### PR DESCRIPTION
Adding log file name to message exceeds size warn in thrift reader. Tested in dev environment:
```
2025-03-28 20:39:48,473 [Processor: 2] (com.pinterest.singer.reader.ThriftLogFileReader:147) WARN  Found a message at offset 954316 that exceeds the size limit in log file: /mnt/thrift_logger/log-benchmark_singer-benchmarking_0.log with messageSize =  141
```