### PR TITLE
Add config to match absolute path for key generation

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -177,6 +177,8 @@ struct S3WriterConfig {
   10: optional string uploaderClass = "com.pinterest.singer.writer.s3.PutObjectUploader";
   // Region of the S3 bucket.
   11: optional string region = "us-east-1";
+  // Use absolute path for filenamePattern regex matching.
+  12: optional bool matchAbsolutePath = false;
 }
 
 enum RealpinObjectType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -122,5 +122,6 @@ public class SingerConfigDef {
   public static final String CANNED_ACL = "cannedAcl";
   public static final String UPLOADER_CLASS = "uploaderClass";
   public static final String REGION = "region";
+  public static final String MATCH_ABSOLUTE_PATH = "matchAbsolutePath";
   public static final String NAMED_GROUP_PATTERN = "\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>";
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -915,6 +915,10 @@ public class LogConfigUtils {
       config.setFilenameTokens(tokenList);
     }
 
+    if (writerConfiguration.containsKey(SingerConfigDef.MATCH_ABSOLUTE_PATH)) {
+      config.setMatchAbsolutePath(writerConfiguration.getBoolean(SingerConfigDef.MATCH_ABSOLUTE_PATH));
+    }
+
     if (writerConfiguration.containsKey(SingerConfigDef.CANNED_ACL)) {
       try {
         // Check if the canned ACL is valid

--- a/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
+++ b/singer/src/test/java/com/pinterest/singer/writer/s3/S3WriterTest.java
@@ -224,6 +224,17 @@ public class S3WriterTest extends SingerTestBase {
     assertEquals("%test_log", objectKeyParts[3]);
     assertEquals("0%", objectKeyParts[4]);
     assertEquals(3, objectKeyParts[5].split("\\.")[0].length());
+
+    // Test with matchAbsolutePath enabled
+    keyFormat =
+        "my-path/%{namespace}/{{" + DefaultTokens.LOGNAME
+            + "}}/%{filename}-%{index}.{{S}}";
+    s3WriterConfig.setKeyFormat(keyFormat);
+    s3WriterConfig.setFilenamePattern(tempPath + "/(?<namespace>[^-]+)-(?<filename>[^.]+)\\.(?<index>\\d+)");
+    s3WriterConfig.setMatchAbsolutePath(true);
+    s3Writer = new S3Writer(logStream, s3WriterConfig, mockS3Uploader, tempPath);
+    objectKeyParts = s3Writer.generateS3ObjectKey().split("/");
+    assertEquals(4, objectKeyParts.length);
   }
 
   @Test


### PR DESCRIPTION
As the title says, this config name `matchAbsolutePath`, when set to true S3Writer will use the logstream's absolute path to build `keyFormat`, otherwise it will use the filename only.