### PR TITLE
MemQ Congestion Control Producer Implementation

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -216,6 +216,8 @@ struct MemqWriterConfig {
   10: optional bool enableRackAwareness = true;
   11: required string cluster;
   12: optional MemqAuditorConfig auditorConfig;
+  13: optional i32 maxInFlightRequestsMemoryBytes = 33554432;  // 32 MB
+  14: optional i32 maxBlockMs = 0; // non-blocking by default
 }
 
 struct PulsarProducerConfig {

--- a/singer/pom.xml
+++ b/singer/pom.xml
@@ -5,7 +5,7 @@
     <description>Logging Agent</description>
     <inceptionYear>2013</inceptionYear>
     <properties>
-        <netty.version>4.1.75.Final</netty.version>
+        <netty.version>4.1.111.Final</netty.version>
     </properties>
     <parent>
         <groupId>com.pinterest.singer</groupId>

--- a/singer/src/main/java/com/pinterest/singer/common/LogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/common/LogStreamProcessor.java
@@ -16,6 +16,7 @@
 package com.pinterest.singer.common;
 
 import com.pinterest.singer.common.errors.LogStreamProcessorException;
+import com.pinterest.singer.common.errors.LogStreamWriterException;
 import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.thrift.LogMessage;
 import com.pinterest.singer.utils.SingerUtils;
@@ -38,7 +39,7 @@ public interface LogStreamProcessor extends Closeable {
    * @return Number of LogMessage processed.
    * @throws LogStreamProcessorException when processor can not process the LogStream.
    */
-  long processLogStream() throws LogStreamProcessorException;
+  long processLogStream() throws LogStreamProcessorException, LogStreamWriterException;
 
   /**
    * Start the LogStream processor.

--- a/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
+++ b/singer/src/main/java/com/pinterest/singer/processor/MemoryEfficientLogStreamProcessor.java
@@ -15,6 +15,8 @@
  */
 package com.pinterest.singer.processor;
 
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
+import com.pinterest.singer.utils.SingerUtils;
 import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -66,6 +68,7 @@ public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor
   protected int processLogMessageBatch() throws IOException, LogStreamWriterException, TException {
     LOG.debug("Start processing a batch of log messages in log stream: {} starting at position: {}",
         logStream, committedPosition);
+    long processingStartTime = System.currentTimeMillis();
     LogPosition batchStartPosition = committedPosition;
 
     int deciderValue = getDeciderValue();
@@ -142,6 +145,9 @@ public class MemoryEfficientLogStreamProcessor extends DefaultLogStreamProcessor
     } else {
       LOG.debug("Done processing log messages in LogStream {} : no new messages.", this.logStream);
     }
+    long processingDuration = System.currentTimeMillis() - processingStartTime;
+    OpenTsdbMetricConverter.gauge("processor.batch_duration_ms", processingDuration,
+        "log=" + logStream.getSingerLog().getSingerLogConfig().getName(), "host=" + SingerUtils.HOSTNAME);
     return logMessagesRead;
   }
 

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -402,6 +402,12 @@ public class LogConfigUtils {
     if (configuration.containsKey("auditor.enabled")) {
       parseMemqAuditorConfigs(config, new SubsetConfiguration(configuration, "auditor"));
     }
+    if (configuration.containsKey("maxInFlightRequestsMemoryBytes")) {
+      config.setMaxInFlightRequestsMemoryBytes(configuration.getInt("maxInFlightRequestsMemoryBytes"));
+    }
+    if (configuration.containsKey("maxBlockMs")) {
+      config.setMaxBlockMs(configuration.getInt("maxBlockMs"));
+    }
     return config;
   }
   

--- a/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/DefaultLogStreamProcessorTest.java
@@ -251,7 +251,7 @@ public class DefaultLogStreamProcessorTest extends com.pinterest.singer.SingerTe
       try {
         processor.processLogStream();
         fail("No exception is thrown on writer error");
-      } catch (LogStreamProcessorException e) {
+      } catch (LogStreamProcessorException | LogStreamWriterException e) {
         // Exception is thrown.
       }
       LogPosition positionAfter = WatermarkUtils.loadCommittedPositionFromWatermark(

--- a/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
+++ b/singer/src/test/java/com/pinterest/singer/processor/TestMemoryEfficientLogStreamProcessor.java
@@ -357,7 +357,7 @@ public class TestMemoryEfficientLogStreamProcessor extends com.pinterest.singer.
       try {
         processor.processLogStream();
         fail("No exception is thrown on writer error");
-      } catch (LogStreamProcessorException e) {
+      } catch (LogStreamProcessorException | LogStreamWriterException e) {
         // Exception is thrown.
       }
       LogPosition positionAfter = WatermarkUtils.loadCommittedPositionFromWatermark(


### PR DESCRIPTION
Producer changes for MemQ congestion control. This PR introduces several changes:

1. 2 new MemqWriter configs: maxInFlightRequestsMemoryBytes and maxBlockMs. maxInFlightRequestsMemoryBytes sets the memory limit that inflight requests can occupy in a single MemqProducer. maxBlockMs sets the max time that a MemqProducer.write() call will block while it waits for sufficient memory to free up to accommodate the next request.
2. LogStreamWriterExceptions are now thrown in LogStreamProcessor.processLogStream(). This is so that the appropriate action can be taken at the Processor level when a LogStreamWriterException is thrown from MemqWriter for memory allocation exceptions. The current handling behavior is unchanged compared to other exceptions - it still relies on retrying the batch via increased processing interval and/or reduced batch size. More specific handling behavior for MemoryAllocationExceptions (wrapped by LogStreamWriterExceptions) can be introduced later on.