### PR TITLE
Add metrics for decider access in singer

### DIFF
--- a/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerMetrics.java
@@ -65,6 +65,8 @@ public class SingerMetrics {
   public static final String PROCESSOR_MESSAGE_VALUE_SIZE_BYTES = "processor.message.value.size.bytes";
   public static final String DISABLE_DECIDER_ACTIVE = "singer.processor.disable_decider_active";
 
+  public static final String DECIDER_ACCESSED = "singer.decider.accessed";
+
   public static final String SKIPPED_BYTES = "singer.reader.skipped_bytes";
   public static final String READER_INODE_MISMATCH = "singer.reader.inode_mismatch";
 

--- a/singer/src/main/java/com/pinterest/singer/config/Decider.java
+++ b/singer/src/main/java/com/pinterest/singer/config/Decider.java
@@ -15,6 +15,8 @@
  */
 package com.pinterest.singer.config;
 
+import com.pinterest.singer.common.SingerMetrics;
+import com.pinterest.singer.metrics.OpenTsdbMetricConverter;
 import com.pinterest.singer.utils.HashUtils;
 import com.pinterest.singer.utils.SingerUtils;
 
@@ -238,6 +240,9 @@ public class Decider {
   public int getDeciderValue(String deciderName, int defaultValue) {
     try {
       deciderName = deciderName.toLowerCase();
+      OpenTsdbMetricConverter.gauge(
+          SingerMetrics.DECIDER_ACCESSED, 1,
+          "name=" + deciderName);
       if (mDeciderMap.containsKey(deciderName)) {
         return mDeciderMap.get(deciderName);
       }


### PR DESCRIPTION
This metric will help determine what deciders each host is accessing.