### PR TITLE
Add content type property to S3Writer

### DIFF
--- a/singer-commons/src/main/thrift/config.thrift
+++ b/singer-commons/src/main/thrift/config.thrift
@@ -179,6 +179,9 @@ struct S3WriterConfig {
   11: optional string region = "us-east-1";
   // Use absolute path for filenamePattern regex matching.
   12: optional bool matchAbsolutePath = false;
+  // The content type header to set for uploaded S3 objects.
+  // e.g. "application/json", "text/plain", etc.
+  13: optional string contentType;
 }
 
 enum RealpinObjectType {

--- a/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
+++ b/singer/src/main/java/com/pinterest/singer/common/SingerConfigDef.java
@@ -127,5 +127,6 @@ public class SingerConfigDef {
   public static final String UPLOADER_CLASS = "uploaderClass";
   public static final String REGION = "region";
   public static final String MATCH_ABSOLUTE_PATH = "matchAbsolutePath";
+  public static final String CONTENT_TYPE = "contentType";
   public static final String NAMED_GROUP_PATTERN = "\\(\\?<([a-zA-Z][a-zA-Z0-9]*)>";
 }

--- a/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
+++ b/singer/src/main/java/com/pinterest/singer/utils/LogConfigUtils.java
@@ -1033,6 +1033,11 @@ public class LogConfigUtils {
       }
       config.setRegion(writerConfiguration.getString(SingerConfigDef.REGION));
     }
+
+    if (writerConfiguration.containsKey(SingerConfigDef.CONTENT_TYPE)) {
+      config.setContentType(writerConfiguration.getString(SingerConfigDef.CONTENT_TYPE));
+    }
+
     return config;
   }
 

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/PutObjectUploader.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/PutObjectUploader.java
@@ -13,19 +13,20 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import java.io.File;
 
 public class PutObjectUploader extends S3Uploader {
+
     private static final Logger LOG = LoggerFactory.getLogger(PutObjectUploader.class);
     private final int maxRetries;
     private static final long INITIAL_BACKOFF = 1000; // Initial backoff in milliseconds
     private static final long MAX_BACKOFF = 32000; // Maximum backoff in milliseconds
 
     public PutObjectUploader(S3WriterConfig s3WriterConfig, S3Client s3Client) {
-      super(s3WriterConfig, s3Client);
-      this.maxRetries = s3WriterConfig.getMaxRetries();
+        super(s3WriterConfig, s3Client);
+        this.maxRetries = s3WriterConfig.getMaxRetries();
     }
 
     /**
-     * Uploads a file to S3 using the PutObject API.
-     * Uses exponential backoff with a cap for retries.
+     * Uploads a file to S3 using the PutObject API. Uses exponential backoff with a cap for
+     * retries.
      *
      * @param s3ObjectUpload the object to upload
      * @return true if the file was successfully uploaded, false otherwise
@@ -40,14 +41,19 @@ public class PutObjectUploader extends S3Uploader {
         while (attempts < maxRetries && !success) {
             attempts++;
             try {
-                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                        .bucket(bucket)
-                        .key(s3Key)
-                        .build();
+                PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key);
 
+                // Add optional fields if present
                 if (cannedAcl != null) {
-                  putObjectRequest = putObjectRequest.toBuilder().acl(cannedAcl).build();
+                    putObjectRequestBuilder = putObjectRequestBuilder.acl(cannedAcl);
                 }
+                if (contentType != null && !contentType.isEmpty()) {
+                    putObjectRequestBuilder = putObjectRequestBuilder.contentType(contentType);
+                }
+
+                PutObjectRequest putObjectRequest = putObjectRequestBuilder.build();
 
                 PutObjectResponse
                     putObjectResponse =

--- a/singer/src/main/java/com/pinterest/singer/writer/s3/S3Uploader.java
+++ b/singer/src/main/java/com/pinterest/singer/writer/s3/S3Uploader.java
@@ -12,12 +12,14 @@ public abstract class S3Uploader {
   protected S3WriterConfig s3WriterConfig;
   protected final ObjectCannedACL cannedAcl;
   protected final String bucket;
+  protected final String contentType;
   protected S3Client s3Client;
 
   public S3Uploader(S3WriterConfig s3WriterConfig, S3Client s3Client) {
     this.s3WriterConfig = s3WriterConfig;
     this.bucket = s3WriterConfig.getBucket();
     this.cannedAcl = ObjectCannedACL.fromValue(s3WriterConfig.getCannedAcl());
+    this.contentType = s3WriterConfig.getContentType();
     this.s3Client = s3Client;
   }
 

--- a/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
+++ b/singer/src/test/java/com/pinterest/singer/utils/TestLogConfigUtils.java
@@ -471,7 +471,7 @@ public class TestLogConfigUtils {
         "type=s3\n" + "s3.bucket=my-fav-bucket\n" + "s3.keyFormat=%{service}/%{index}/my_log\n"
             + "s3.maxFileSizeMB=100\n" + "s3.minUploadTimeInSeconds=1\n" + "s3.maxRetries=10\n"
             + "s3.filenamePattern=^(?<service>[a-zA-Z0-9]+)_.*_(?<index>\\\\d+)\\\\.log$\n"
-            + "s3.cannedAcl=bucket-owner-full-control";
+            + "s3.cannedAcl=bucket-owner-full-control\n" + "s3.contentType=application/json";
     PropertiesConfiguration conf = new PropertiesConfiguration();
     conf.load(new ByteArrayInputStream(config.getBytes()));
     List<String> tokens = new ArrayList<>();


### PR DESCRIPTION
This PR adds a contentType property to the S3Writer to allow specifying the content type for files uploaded to S3. This is to enable setting the correct Content-Type metadata for S3 objects, improving compatibility and browser handling.